### PR TITLE
Add IPC Path Flag to sharding client

### DIFF
--- a/cmd/geth/shardingcmd.go
+++ b/cmd/geth/shardingcmd.go
@@ -14,7 +14,7 @@ var (
 		Aliases:   []string{"shard"},
 		Usage:     "Start a sharding client",
 		ArgsUsage: "[endpoint]",
-		Flags:     []cli.Flag{utils.DataDirFlag, utils.PasswordFileFlag, utils.NetworkIdFlag},
+		Flags:     []cli.Flag{utils.DataDirFlag, utils.PasswordFileFlag, utils.NetworkIdFlag,utils.IPCPathFlag},
 		Category:  "SHARDING COMMANDS",
 		Description: `
 Launches a sharding client that connects to a running geth node and proposes collations to a Validator Manager Contract. This feature is a work in progress.

--- a/sharding/client.go
+++ b/sharding/client.go
@@ -45,6 +45,9 @@ func MakeShardingClient(ctx *cli.Context) *Client {
 	if endpoint == "" {
 		endpoint = fmt.Sprintf("%s/%s.ipc", path, clientIdentifier)
 	}
+	if ctx.GlobalIsSet(utils.IPCPathFlag.Name) {
+		endpoint = ctx.GlobalString(utils.IPCPathFlag.Name)
+	}
 
 	config := &node.Config{
 		DataDir: path,


### PR DESCRIPTION
In windows the IPC endpoint opens in //./pipe/geth.ipc than in the data directory. IPCPath flag is added so that it can be specified when running the sharding client