### PR TITLE
verify the client is in validator pool before querying for eligible proposer

### DIFF
--- a/sharding/collator.go
+++ b/sharding/collator.go
@@ -98,8 +98,8 @@ func checkShardsForProposal(c collatorClient, head *types.Header) error {
 	return nil
 }
 
-// checkForValidators checks if the client is in the validator pool because
-// we can't guarantee our tx for deposit will be in the next block header we receive
+// isAccountInValidatorSet checks if the client is in the validator pool because
+// we can't guarantee our tx for deposit will be in the next block header we receive.
 // The function calls IsValidatorDeposited from the VMC and returns true if
 // the client is in the validator pool
 func isAccountInValidatorSet(c collatorClient) (bool, error) {

--- a/sharding/collator.go
+++ b/sharding/collator.go
@@ -52,7 +52,7 @@ func subscribeBlockHeaders(c collatorClient) error {
 			return fmt.Errorf("unable to verify client in validator pool. %v", err)
 		}
 
-		if (v) {
+		if v {
 			if err := checkShardsForProposal(c, head); err != nil {
 				return fmt.Errorf("unable to watch shards. %v", err)
 			}


### PR DESCRIPTION
Header 5418 was skipped and warning message was logged
Header 5419 has the client address, get eligible proposer was called

./build/bin/geth shard --datadir=../datadir/ --password=password.txt
INFO [02-26|14:45:16] Starting sharding client
INFO [02-26|14:45:16] No validator management contract found at 0x0000000000000000000000000000000000000000. Deploying new contract.
INFO [02-26|14:45:44] New contract deployed at 0xbffa8d2f672403052d84769F08a83A2B5C5e17D7
INFO [02-26|14:45:46] Deposited 100ETH into contract with transaction hash: 0x54382051352db9abbf4fdd1b1e4177788fa92f9755130c3790223ac3569c4c8b
INFO [02-26|14:45:46] Listening for new headers...
**INFO [02-26|14:45:51] Received new header: 5418
WARN [02-26|14:45:53] client not in validator set, re-try next block
INFO [02-26|14:46:06] Received new header: 5419**
INFO [02-26|14:46:09] Checking if we are an eligible collation proposer for a shard...
INFO [02-26|14:46:09] Selected as collator on shard: 0
INFO [02-26|14:46:09] Propose collation function called
INFO [02-26|14:46:09] Selected as collator on shard: 1
INFO [02-26|14:46:09] Propose collation function called
INFO [02-26|14:46:09] Selected as collator on shard: 2
INFO [02-26|14:46:09] Propose collation function called