### PR TITLE
refactor account interface, and unlock account when client is created

### DIFF
--- a/sharding/client.go
+++ b/sharding/client.go
@@ -81,6 +81,16 @@ func (c *Client) Start() error {
 	c.client = ethclient.NewClient(rpcClient)
 	defer rpcClient.Close()
 
+	// Check account existence and unlock account before starting sharding client
+	accounts := c.keystore.Accounts()
+	if len(accounts) == 0 {
+		return fmt.Errorf("no accounts found")
+	}
+
+	if err := c.unlockAccount(accounts[0]); err != nil {
+		return fmt.Errorf("cannot unlock account. %v", err)
+	}
+
 	if err := initVMC(c); err != nil {
 		return err
 	}
@@ -132,10 +142,7 @@ func (c *Client) unlockAccount(account accounts.Account) error {
 }
 
 func (c *Client) createTXOps(value *big.Int) (*bind.TransactOpts, error) {
-	account, err := c.Account()
-	if err != nil {
-		return nil, err
-	}
+	account := c.Account()
 
 	return &bind.TransactOpts{
 		From:  account.Address,
@@ -151,17 +158,10 @@ func (c *Client) createTXOps(value *big.Int) (*bind.TransactOpts, error) {
 }
 
 // Account to use for sharding transactions.
-func (c *Client) Account() (*accounts.Account, error) {
+func (c *Client) Account() *accounts.Account {
 	accounts := c.keystore.Accounts()
-	if len(accounts) == 0 {
-		return nil, fmt.Errorf("no accounts found")
-	}
 
-	if err := c.unlockAccount(accounts[0]); err != nil {
-		return nil, fmt.Errorf("cannot unlock account. %v", err)
-	}
-
-	return &accounts[0], nil
+	return &accounts[0]
 }
 
 // ChainReader for interacting with the chain.

--- a/sharding/collator.go
+++ b/sharding/collator.go
@@ -14,7 +14,7 @@ import (
 )
 
 type collatorClient interface {
-	Account() (*accounts.Account, error)
+	Account() *accounts.Account
 	ChainReader() ethereum.ChainReader
 	VMCCaller() *contracts.VMCCaller
 }
@@ -27,12 +27,9 @@ type collatorClient interface {
 func subscribeBlockHeaders(c collatorClient) error {
 	headerChan := make(chan *types.Header, 16)
 
-	account, err := c.Account()
-	if err != nil {
-		return err
-	}
+	account := c.Account()
 
-	_, err = c.ChainReader().SubscribeNewHead(context.Background(), headerChan)
+	_, err := c.ChainReader().SubscribeNewHead(context.Background(), headerChan)
 	if err != nil {
 		return fmt.Errorf("unable to subscribe to incoming headers. %v", err)
 	}
@@ -68,10 +65,7 @@ func subscribeBlockHeaders(c collatorClient) error {
 // getEligibleProposer from the VMC and proposes a collation if
 // conditions are met
 func checkShardsForProposal(c collatorClient, head *types.Header) error {
-	account, err := c.Account()
-	if err != nil {
-		return err
-	}
+	account := c.Account()
 
 	log.Info("Checking if we are an eligible collation proposer for a shard...")
 	period := big.NewInt(0).Div(head.Number, big.NewInt(periodLength))
@@ -103,10 +97,7 @@ func checkShardsForProposal(c collatorClient, head *types.Header) error {
 // The function calls IsValidatorDeposited from the VMC and returns true if
 // the client is in the validator pool
 func isAccountInValidatorSet(c collatorClient) (bool, error) {
-	account, err := c.Account()
-	if err != nil {
-		return false, err
-	}
+	account := c.Account()
 
 	// Checks if our deposit has gone through according to the VMC
 	b, err := c.VMCCaller().IsValidatorDeposited(&bind.CallOpts{}, account.Address)

--- a/sharding/collator_test.go
+++ b/sharding/collator_test.go
@@ -23,8 +23,8 @@ type FakeCollatorClient struct {
 	contractCaller FakeContractCaller
 }
 
-func (c FakeCollatorClient) Account() (*accounts.Account, error) {
-	return c.accountAccount, c.accountError
+func (c FakeCollatorClient) Account() *accounts.Account {
+	return c.accountAccount
 }
 
 func (c FakeCollatorClient) ChainReader() ethereum.ChainReader {


### PR DESCRIPTION
This addresses #42. Tested with both scenarios:
1) correct password
`❰terencetsao❙~/prysmaticlabs/geth-sharding(git✱≠refactorAccounts)❱✘≻
./build/bin/geth shard --datadir=../datadir/ --password=password.txt
INFO [02-27|09:00:31] Starting sharding client
INFO [02-27|09:00:32] No validator management contract found at 0x0000000000000000000000000000000000000000. Deploying new contract.
INFO [02-27|09:00:49] New contract deployed at 0xe5126F4b9d7D6F9eB1B4954519469ccbf4fe52Cc
INFO [02-27|09:00:49] Deposited 100ETH into contract with transaction hash: 0xf89755adc63b82ccfd8a58c9911e1507d3d083f4b8bf6d5f87819031170e3caf
INFO [02-27|09:00:49] Listening for new headers...
`
2) incorrect password
`./build/bin/geth shard --datadir=../datadir/ --password=password.txt
INFO [02-27|09:01:20] Starting sharding client
cannot unlock account. could not decrypt key with given passphrase`