### PR TITLE
Proposing cli entrypoint name change as sharding-validator instead of geth shard --validator

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -122,7 +122,7 @@ var (
 		utils.GpoBlocksFlag,
 		utils.GpoPercentileFlag,
 		utils.ExtraDataFlag,
-		utils.JoinValidatorSetFlag,
+		utils.DepositFlag,
 		configFileFlag,
 	}
 

--- a/cmd/geth/shardingcmd.go
+++ b/cmd/geth/shardingcmd.go
@@ -10,11 +10,11 @@ import (
 var (
 	shardingClientCommand = cli.Command{
 		Action:    utils.MigrateFlags(shardingClient),
-		Name:      "sharding",
-		Aliases:   []string{"shard"},
-		Usage:     "Start a sharding client",
+		Name:      "sharding-validator",
+		Aliases:   []string{"shard-validator"},
+		Usage:     "Start a sharding validator client",
 		ArgsUsage: "[endpoint]",
-		Flags:     []cli.Flag{utils.DataDirFlag, utils.PasswordFileFlag, utils.NetworkIdFlag, utils.IPCPathFlag, utils.JoinValidatorSetFlag},
+		Flags:     []cli.Flag{utils.DataDirFlag, utils.PasswordFileFlag, utils.NetworkIdFlag, utils.IPCPathFlag, utils.DepositFlag},
 		Category:  "SHARDING COMMANDS",
 		Description: `
 Launches a sharding client that connects to a running geth node and proposes collations to a Validator Manager Contract. This feature is a work in progress.

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -539,8 +539,8 @@ var (
 	}
 
 	//Sharding Settings
-	JoinValidatorSetFlag = cli.BoolFlag{
-		Name:  "validator",
+	DepositFlag = cli.BoolFlag{
+		Name:  "deposit",
 		Usage: "To become a validator with your sharding client, 100 ETH will be deposited from user's account into VMC ",
 	}
 )

--- a/sharding/vmc.go
+++ b/sharding/vmc.go
@@ -56,7 +56,7 @@ func initVMC(c *Client) error {
 // the account is not in the set, it will deposit 100ETH into contract.
 func joinValidatorSet(c *Client) error {
 
-	if c.ctx.GlobalBool(utils.JoinValidatorSetFlag.Name) {
+	if c.ctx.GlobalBool(utils.DepositFlag.Name) {
 
 		log.Info("Joining validator set")
 		txOps, err := c.createTXOps(depositSize)


### PR DESCRIPTION
To be consistent with the documentation in #51, I propose we change the main geth entrypoint to become a validator to the following:

```
$ geth sharding-validator --deposit --datadir /path/to/your/datadir --password /path/to/your/password.txt --networkid 12345
```

Just changed all the necessary items and this now works. Tests pass.