### PR TITLE
Fixing Comment Formatting According to Best Linter Practices

### DIFF
--- a/sharding/client/client.go
+++ b/sharding/client/client.go
@@ -1,6 +1,6 @@
 // Package client provides an interface for interacting with a running ethereum full node.
 // As part of the initial phases of sharding, actors will need access to the sharding management
-// contract on the main PoW chain.
+// contract on the main PoW chain
 package client
 
 import (
@@ -33,8 +33,7 @@ const (
 	clientIdentifier = "geth" // Used to determine the ipc name.
 )
 
-// General client for Notary/Proposer. Communicates to Geth node via JSON RPC.
-
+// General client for Notary/Proposer - Communicates to Geth node via JSON RPC
 type shardingClient struct {
 	endpoint  string             // Endpoint to JSON RPC
 	client    *ethclient.Client  // Ethereum RPC client.
@@ -44,6 +43,7 @@ type shardingClient struct {
 	rpcClient *rpc.Client        // The RPC client connection to the main geth node
 }
 
+// Client methods that must be implemented to run a sharded system
 type Client interface {
 	Start() error
 	Close()
@@ -54,6 +54,7 @@ type Client interface {
 	SMCTransactor() *contracts.SMCTransactor
 }
 
+// NewClient forms a new struct instance
 func NewClient(ctx *cli.Context) *shardingClient {
 	path := node.DefaultDataDir()
 	if ctx.GlobalIsSet(utils.DataDirFlag.Name) {
@@ -85,9 +86,9 @@ func NewClient(ctx *cli.Context) *shardingClient {
 	}
 }
 
-// Start the sharding client.
-// * Connects to Geth node.
-// * Verifies or deploys the sharding manager contract.
+// Start the sharding client
+// Connects to Geth node
+// Verifies or deploys the sharding manager contract
 func (c *shardingClient) Start() error {
 	rpcClient, err := dialRPC(c.endpoint)
 	if err != nil {

--- a/sharding/client/client.go
+++ b/sharding/client/client.go
@@ -55,7 +55,7 @@ type Client interface {
 }
 
 // NewClient forms a new struct instance
-func NewClient(ctx *cli.Context) *shardingClient {
+func NewClient(ctx *cli.Context) Client {
 	path := node.DefaultDataDir()
 	if ctx.GlobalIsSet(utils.DataDirFlag.Name) {
 		path = ctx.GlobalString(utils.DataDirFlag.Name)

--- a/sharding/client/client.go
+++ b/sharding/client/client.go
@@ -185,6 +185,7 @@ func (c *shardingClient) SMCCaller() *contracts.SMCCaller {
 	return &c.smc.SMCCaller
 }
 
+// SMCTransactor allows us to send tx's to the SMC programmatically
 func (c *shardingClient) SMCTransactor() *contracts.SMCTransactor {
 	return &c.smc.SMCTransactor
 }

--- a/sharding/collation.go
+++ b/sharding/collation.go
@@ -1,18 +1,19 @@
 package sharding
 
 import (
-	"math"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 )
 
+// Collation base struct
 type Collation struct {
 	header       *CollationHeader
 	transactions []*types.Transaction
 }
 
+// CollationHeader base struct
 type CollationHeader struct {
 	shardID           *big.Int        //the shard ID of the shard
 	chunkRoot         *common.Hash    //the root of the chunk tree which identifies collation body
@@ -21,27 +22,26 @@ type CollationHeader struct {
 	proposerSignature []byte          //the proposer's signature for calculating collation hash
 }
 
-func (c *Collation) Header() *CollationHeader           { return c.header }
-func (c *Collation) Transactions() []*types.Transaction { return c.transactions }
-func (c *Collation) ShardID() *big.Int                  { return c.header.shardID }
-func (c *Collation) Period() *big.Int                   { return c.header.period }
-func (c *Collation) ProposerAddress() *common.Address   { return c.header.proposerAddress }
+// Header returns the collation's header
+func (c *Collation) Header() *CollationHeader { return c.header }
 
+// Transactions returns an array of tx's in the collation
+func (c *Collation) Transactions() []*types.Transaction { return c.transactions }
+
+// ShardID is the identifier for a shard
+func (c *Collation) ShardID() *big.Int { return c.header.shardID }
+
+// Period the collation corresponds to
+func (c *Collation) Period() *big.Int { return c.header.period }
+
+// ProposerAddress is the coinbase addr of the creator for the collation
+func (c *Collation) ProposerAddress() *common.Address { return c.header.proposerAddress }
+
+// SetHeader updates the collation's header
 func (c *Collation) SetHeader(h *CollationHeader) { c.header = h }
 
+// AddTransaction adds to the collation's body of tx blobs
 func (c *Collation) AddTransaction(tx *types.Transaction) {
-	// TODO: Check transaction does not exceed gas limit
+	// TODO: Include blob serialization instead
 	c.transactions = append(c.transactions, tx)
-}
-
-func (c *Collation) GasUsed() *big.Int {
-	g := uint64(0)
-	for _, tx := range c.transactions {
-		if g > math.MaxUint64-(g+tx.Gas()) {
-			g = math.MaxUint64
-			break
-		}
-		g += tx.Gas()
-	}
-	return big.NewInt(0).SetUint64(g)
 }

--- a/sharding/config.go
+++ b/sharding/config.go
@@ -7,32 +7,33 @@ import (
 )
 
 var (
-	// Number of network shards
+	// ShardCount is the number of network shards
 	ShardCount = int64(100)
-	// Address of the sharding manager contract
+	// ShardingManagerAddress is the address of the sharding manager contract
 	ShardingManagerAddress = common.HexToAddress("0x0") // TODO
-	// Gas limit for verifying signatures
+	// SigGasLimit for verifying signatures
 	SigGasLimit = 40000
-	// Number of blocks in a period
+	// PeriodLength is num of blocks in period
 	PeriodLength = int64(5)
-	// Number of periods ahead of current period which the contract is able to return the notary of that period.
+	// LookaheadPeriods is the umber of periods ahead of current period
+	// which the contract is able to return the notary of that period
 	LookaheadPeriods = 4
-	// Required deposit size in wei for notary
+	// NotaryDeposit is a required deposit size in wei
 	NotaryDeposit = new(big.Int).Exp(big.NewInt(10), big.NewInt(21), nil) // 1000 ETH
-	// Required deposit size in wei for proposer
+	// ProposerDeposit is a required deposit size in wei
 	ProposerDeposit = new(big.Int).Exp(big.NewInt(10), big.NewInt(18), nil) // 1 ETH
-	// Minimum Balance of proposer where bids are deducted
+	// MinProposerBalance of proposer where bids are deducted
 	MinProposerBalance = new(big.Int).Exp(big.NewInt(10), big.NewInt(17), nil) // 0.1 ETH
-	// Gas limit to create contract
+	// ContractGasLimit to create contract
 	ContractGasLimit = uint64(4700000) // Max is 4712388
-	// Number of periods to lockup notary deposit from time of deregistration
+	// NotaryLockupLength to lockup notary deposit from time of deregistration
 	NotaryLockupLength = int64(16128)
-	// Number of periods to lockup proposer deposit from time of deregistration
+	// ProposerLockupLength to lockup proposer deposit from time of deregistration
 	ProposerLockupLength = int64(48)
-	// Number of ETH awarded to notary after collation included in canonical chain
+	// NotarySubsidy is ETH awarded to notary after collation included in canonical chain
 	NotarySubsidy = new(big.Int).Exp(big.NewInt(10), big.NewInt(15), nil) // 0.001 ETH
-	// Number of notaries sampled per block from the notaries pool per period per shard
+	// NotaryCommitSize sampled per block from the notaries pool per period per shard
 	NotaryCommitSize = int64(135)
-	// Number of notary votes the collation needs to get accepted to the canonical chain
+	// NotaryQuorumSize votes the collation needs to get accepted to the canonical chain
 	NotaryQuorumSize = int64(90)
 )

--- a/sharding/notary/notary_client.go
+++ b/sharding/notary/notary_client.go
@@ -1,4 +1,3 @@
-// Package notary holds all of the functionality to run as a notary in a sharded system.
 package notary
 
 import (
@@ -7,9 +6,9 @@ import (
 	cli "gopkg.in/urfave/cli.v1"
 )
 
-// Notary runnable client.
+// Notary runnable client
 type Notary interface {
-	// Start the main routine for a notary.
+	// Start the main routine for a notary
 	Start() error
 }
 
@@ -17,14 +16,14 @@ type notary struct {
 	client client.Client
 }
 
-// NewNotary creates a new notary instance.
+// NewNotary creates a new notary instance
 func NewNotary(ctx *cli.Context) Notary {
 	return &notary{
 		client: client.NewClient(ctx),
 	}
 }
 
-// Start the main routine for a notary.
+// Start the main routine for a notary
 func (c *notary) Start() error {
 	log.Info("Starting notary client")
 	err := c.client.Start()

--- a/sharding/proposer/proposer_client.go
+++ b/sharding/proposer/proposer_client.go
@@ -1,5 +1,3 @@
-// Package proposer holds all of the functionality to run as a collation proposer in a sharded
-// system.
 package proposer
 
 import (
@@ -8,6 +6,8 @@ import (
 	cli "gopkg.in/urfave/cli.v1"
 )
 
+// Proposer holds functionality required to run a collation proposer
+// in a sharded system
 type Proposer interface {
 	Start() error
 }
@@ -16,12 +16,14 @@ type proposer struct {
 	client client.Client
 }
 
+// NewProposer creates a struct instance
 func NewProposer(ctx *cli.Context) Proposer {
 	return &proposer{
 		client: client.NewClient(ctx),
 	}
 }
 
+// Start the main entry point for proposing collations
 func (p *proposer) Start() error {
 	log.Info("Starting proposer client")
 	err := p.client.Start()


### PR DESCRIPTION
Hi all,

This is a quick PR done to fix the comment formatting across our packages. I always get warnings from my linters in VSCode due to the problem of not commenting exported types. This is something we should do and is best practice. For example, if I create a type:

```go
type Collation struct {
  header *CollationHeader
  body *CollationBody
}
```

We have to add a comment above that begins with the name of the type as follows:

```go
// Collation defines the base struct for a sharding primitive
type Collation struct {
  header *CollationHeader
  body *CollationBody
}
```

Also removed punctuation from some comments in order to be consistent with our other comments throughout our packages.
