### PR TITLE
Only run travis tests on go 1.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,16 +3,16 @@ go_import_path: github.com/ethereum/go-ethereum
 sudo: false
 matrix:
   include:
-    - os: linux
-      dist: trusty
-      sudo: required
-      go: 1.9.x
-      script:
-        - sudo modprobe fuse
-        - sudo chmod 666 /dev/fuse
-        - sudo chown root:$USER /etc/fuse.conf
-        - go run build/ci.go install
-        - go run build/ci.go test -coverage
+    #- os: linux
+    #  dist: trusty
+    #  sudo: required
+    #  go: 1.9.x
+    #  script:
+    #    - sudo modprobe fuse
+    #    - sudo chmod 666 /dev/fuse
+    #    - sudo chown root:$USER /etc/fuse.conf
+    #    - go run build/ci.go install
+    #    - go run build/ci.go test -coverage
 
     # These are the latest Go versions.
     - os: linux
@@ -26,15 +26,15 @@ matrix:
         - go run build/ci.go install
         - go run build/ci.go test -coverage
 
-    - os: osx
-      go: "1.10"
-      script:
-        - unset -f cd # workaround for https://github.com/travis-ci/travis-ci/issues/8703
-        - brew update
-        - brew install caskroom/cask/brew-cask
-        - brew cask install osxfuse
-        - go run build/ci.go install
-        - go run build/ci.go test -coverage
+    #- os: osx
+    #  go: "1.10"
+    #  script:
+    #    - unset -f cd # workaround for https://github.com/travis-ci/travis-ci/issues/8703
+    #    - brew update
+    #    - brew install caskroom/cask/brew-cask
+    #    - brew cask install osxfuse
+    #    - go run build/ci.go install
+    #    - go run build/ci.go test -coverage
 
     # This builder only tests code linters on latest version of Go
     - os: linux


### PR DESCRIPTION
This should reduce the amount of flaky test failures.