### PR TITLE
Refactor common test steps into helper functions in SMC tests 

### DIFF
--- a/sharding/contracts/sharding_manager_test.go
+++ b/sharding/contracts/sharding_manager_test.go
@@ -21,6 +21,12 @@ type SMCConfig struct {
 	proposerLockupLength *big.Int
 }
 
+type testAccount struct {
+	addr    common.Address
+	privKey *ecdsa.PrivateKey
+	txOpts  *bind.TransactOpts
+}
+
 var (
 	mainKey, _                   = crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
 	accountBalance2000Eth, _     = new(big.Int).SetString("2000000000000000000000", 10)
@@ -33,6 +39,24 @@ var (
 	}
 	ctx = context.Background()
 )
+
+// initAccounts initializes back end with the number of test accounts
+// returns an array of test accounts
+func initAccounts(n int) ([]testAccount, map[common.Address]core.GenesisAccount) {
+	genesis := make(core.GenesisAlloc)
+	var testAccounts []testAccount
+
+	for i := 0; i < n; i++ {
+		privKey, _ := crypto.GenerateKey()
+		addr := crypto.PubkeyToAddress(privKey.PublicKey)
+		txOpts := bind.NewKeyedTransactor(privKey)
+		testAccounts = append(testAccounts, testAccount{addr, privKey, txOpts})
+		genesis[addr] = core.GenesisAccount{
+			Balance: accountBalance2000Eth,
+		}
+	}
+	return testAccounts, genesis
+}
 
 // deploySMCContract is a helper function for deploying SMC.
 func deploySMCContract(backend *backends.SimulatedBackend, key *ecdsa.PrivateKey) (common.Address, *types.Transaction, *SMC, error) {
@@ -55,28 +79,15 @@ func TestContractCreation(t *testing.T) {
 // TestNotaryRegister tests notary registers in a normal condition.
 func TestNotaryRegister(t *testing.T) {
 	const notaryCount = 3
-	var notaryPoolAddr [notaryCount]common.Address
-	var notaryPoolPrivKeys [notaryCount]*ecdsa.PrivateKey
-	var txOpts [notaryCount]*bind.TransactOpts
-	genesis := make(core.GenesisAlloc)
 
-	// Initializes back end with 3 accounts and each with 2000 eth balances.
-	for i := 0; i < notaryCount; i++ {
-		key, _ := crypto.GenerateKey()
-		notaryPoolPrivKeys[i] = key
-		notaryPoolAddr[i] = crypto.PubkeyToAddress(key.PublicKey)
-		txOpts[i] = bind.NewKeyedTransactor(key)
-		txOpts[i].Value = notaryDeposit
-		genesis[notaryPoolAddr[i]] = core.GenesisAccount{
-			Balance: accountBalance2000Eth,
-		}
-	}
+	// Initializes 3 accounts to register as notaries.
+	notaryPool, genesis := initAccounts(notaryCount)
 
 	backend := backends.NewSimulatedBackend(genesis)
-	_, _, smc, _ := deploySMCContract(backend, notaryPoolPrivKeys[0])
+	_, _, smc, _ := deploySMCContract(backend, notaryPool[0].privKey)
 
 	// Notary 0 has not registered.
-	notary, err := smc.NotaryRegistry(&bind.CallOpts{}, notaryPoolAddr[0])
+	notary, err := smc.NotaryRegistry(&bind.CallOpts{}, notaryPool[0].addr)
 	if err != nil {
 		t.Fatalf("Can't get notary registry info: %v", err)
 	}
@@ -86,12 +97,13 @@ func TestNotaryRegister(t *testing.T) {
 	}
 
 	// Test notary 0 has registered.
-	if _, err := smc.RegisterNotary(txOpts[0]); err != nil {
+	notaryPool[0].txOpts.Value = notaryDeposit
+	if _, err := smc.RegisterNotary(notaryPool[0].txOpts); err != nil {
 		t.Fatalf("Registering notary has failed: %v", err)
 	}
 	backend.Commit()
 
-	notary, err = smc.NotaryRegistry(&bind.CallOpts{}, notaryPoolAddr[0])
+	notary, err = smc.NotaryRegistry(&bind.CallOpts{}, notaryPool[0].addr)
 
 	if !notary.Deposited ||
 		notary.PoolIndex.Cmp(big.NewInt(0)) != 0 ||
@@ -101,17 +113,19 @@ func TestNotaryRegister(t *testing.T) {
 	}
 
 	// Test notary 1 and 2 have registered.
-	if _, err := smc.RegisterNotary(txOpts[1]); err != nil {
+	notaryPool[1].txOpts.Value = notaryDeposit
+	if _, err := smc.RegisterNotary(notaryPool[1].txOpts); err != nil {
 		t.Fatalf("Registering notary has failed: %v", err)
 	}
 	backend.Commit()
 
-	if _, err := smc.RegisterNotary(txOpts[2]); err != nil {
+	notaryPool[2].txOpts.Value = notaryDeposit
+	if _, err := smc.RegisterNotary(notaryPool[2].txOpts); err != nil {
 		t.Fatalf("Registering notary has failed: %v", err)
 	}
 	backend.Commit()
 
-	notary, err = smc.NotaryRegistry(&bind.CallOpts{}, notaryPoolAddr[1])
+	notary, err = smc.NotaryRegistry(&bind.CallOpts{}, notaryPool[1].addr)
 
 	if !notary.Deposited ||
 		notary.PoolIndex.Cmp(big.NewInt(1)) != 0 ||
@@ -120,7 +134,7 @@ func TestNotaryRegister(t *testing.T) {
 			"Got - deposited:%v, index:%v, period:%v ", notary.Deposited, notary.PoolIndex, notary.DeregisteredPeriod)
 	}
 
-	notary, err = smc.NotaryRegistry(&bind.CallOpts{}, notaryPoolAddr[2])
+	notary, err = smc.NotaryRegistry(&bind.CallOpts{}, notaryPool[2].addr)
 
 	if !notary.Deposited ||
 		notary.PoolIndex.Cmp(big.NewInt(2)) != 0 ||
@@ -141,18 +155,16 @@ func TestNotaryRegister(t *testing.T) {
 
 // TestNotaryRegisterInsufficientEther tests notary registers with insufficient deposit.
 func TestNotaryRegisterInsufficientEther(t *testing.T) {
-	addr := crypto.PubkeyToAddress(mainKey.PublicKey)
-	backend := backends.NewSimulatedBackend(core.GenesisAlloc{addr: {Balance: accountBalance2000Eth}})
-	txOpts := bind.NewKeyedTransactor(mainKey)
-	txOpts.Value = notaryDepositInsufficient
-	_, _, smc, _ := deploySMCContract(backend, mainKey)
-
-	_, err := smc.RegisterNotary(txOpts)
+	notaryPool, genesis := initAccounts(1)
+	backend := backends.NewSimulatedBackend(genesis)
+	_, _, smc, _ := deploySMCContract(backend, notaryPool[0].privKey)
+	notaryPool[0].txOpts.Value = notaryDepositInsufficient
+	_, err := smc.RegisterNotary(notaryPool[0].txOpts)
 	if err == nil {
 		t.Errorf("Notary register should have failed with insufficient deposit")
 	}
 
-	notary, _ := smc.NotaryRegistry(&bind.CallOpts{}, addr)
+	notary, _ := smc.NotaryRegistry(&bind.CallOpts{}, notaryPool[0].addr)
 	numNotaries, _ := smc.NotaryPoolLength(&bind.CallOpts{})
 
 	if notary.Deposited {
@@ -167,17 +179,16 @@ func TestNotaryRegisterInsufficientEther(t *testing.T) {
 
 // TestNotaryDoubleRegisters tests notary registers twice.
 func TestNotaryDoubleRegisters(t *testing.T) {
-	addr := crypto.PubkeyToAddress(mainKey.PublicKey)
-	backend := backends.NewSimulatedBackend(core.GenesisAlloc{addr: {Balance: accountBalance2000Eth}})
-	txOpts := bind.NewKeyedTransactor(mainKey)
-	txOpts.Value = notaryDeposit
-	_, _, smc, _ := deploySMCContract(backend, mainKey)
+	notaryPool, genesis := initAccounts(1)
+	backend := backends.NewSimulatedBackend(genesis)
+	_, _, smc, _ := deploySMCContract(backend, notaryPool[0].privKey)
 
 	// Notary 0 registers.
-	smc.RegisterNotary(txOpts)
+	notaryPool[0].txOpts.Value = notaryDeposit
+	smc.RegisterNotary(notaryPool[0].txOpts)
 	backend.Commit()
 
-	notary, _ := smc.NotaryRegistry(&bind.CallOpts{}, addr)
+	notary, _ := smc.NotaryRegistry(&bind.CallOpts{}, notaryPool[0].addr)
 	numNotaries, _ := smc.NotaryPoolLength(&bind.CallOpts{})
 
 	if !notary.Deposited {
@@ -189,7 +200,7 @@ func TestNotaryDoubleRegisters(t *testing.T) {
 	}
 
 	// Notary 0 registers again.
-	_, err := smc.RegisterNotary(txOpts)
+	_, err := smc.RegisterNotary(notaryPool[0].txOpts)
 	if err == nil {
 		t.Errorf("Notary register should have failed with double registers")
 	}
@@ -201,17 +212,16 @@ func TestNotaryDoubleRegisters(t *testing.T) {
 
 // TestNotaryDeregister tests notary deregisters in a normal condition.
 func TestNotaryDeregister(t *testing.T) {
-	addr := crypto.PubkeyToAddress(mainKey.PublicKey)
-	backend := backends.NewSimulatedBackend(core.GenesisAlloc{addr: {Balance: accountBalance2000Eth}})
-	txOpts := bind.NewKeyedTransactor(mainKey)
-	txOpts.Value = notaryDeposit
-	_, _, smc, _ := deploySMCContract(backend, mainKey)
+	notaryPool, genesis := initAccounts(1)
+	backend := backends.NewSimulatedBackend(genesis)
+	_, _, smc, _ := deploySMCContract(backend, notaryPool[0].privKey)
 
 	// Notary 0 registers.
-	smc.RegisterNotary(txOpts)
+	notaryPool[0].txOpts.Value = notaryDeposit
+	smc.RegisterNotary(notaryPool[0].txOpts)
 	backend.Commit()
 
-	notary, _ := smc.NotaryRegistry(&bind.CallOpts{}, addr)
+	notary, _ := smc.NotaryRegistry(&bind.CallOpts{}, notaryPool[0].addr)
 	numNotaries, _ := smc.NotaryPoolLength(&bind.CallOpts{})
 
 	if !notary.Deposited {
@@ -228,15 +238,15 @@ func TestNotaryDeregister(t *testing.T) {
 	}
 
 	// Notary 0 deregisters.
-	txOpts = bind.NewKeyedTransactor(mainKey)
-	_, err := smc.DeregisterNotary(txOpts)
+	notaryPool[0].txOpts = bind.NewKeyedTransactor(notaryPool[0].privKey)
+	_, err := smc.DeregisterNotary(notaryPool[0].txOpts)
 	if err != nil {
 		t.Fatalf("Failed to deregister notary: %v", err)
 	}
 	backend.Commit()
 
 	// Verify notary has saved the deregistered period as: current block number / period length.
-	notary, _ = smc.NotaryRegistry(&bind.CallOpts{}, addr)
+	notary, _ = smc.NotaryRegistry(&bind.CallOpts{}, notaryPool[0].addr)
 	currentPeriod := big.NewInt(int64(FastForward100Blocks) / sharding.PeriodLength)
 	if currentPeriod.Cmp(notary.DeregisteredPeriod) != 0 {
 		t.Errorf("Incorrect notary degister period. Want: %v, Got: %v ", currentPeriod, notary.DeregisteredPeriod)
@@ -250,17 +260,16 @@ func TestNotaryDeregister(t *testing.T) {
 
 // TestNotaryDeregisterThenRegister tests notary deregisters then registers before lock up ends.
 func TestNotaryDeregisterThenRegister(t *testing.T) {
-	addr := crypto.PubkeyToAddress(mainKey.PublicKey)
-	backend := backends.NewSimulatedBackend(core.GenesisAlloc{addr: {Balance: accountBalance2000Eth}})
-	txOpts := bind.NewKeyedTransactor(mainKey)
-	txOpts.Value = notaryDeposit
-	_, _, smc, _ := deploySMCContract(backend, mainKey)
+	notaryPool, genesis := initAccounts(1)
+	backend := backends.NewSimulatedBackend(genesis)
+	_, _, smc, _ := deploySMCContract(backend, notaryPool[0].privKey)
 
 	// Notary 0 registers.
-	smc.RegisterNotary(txOpts)
+	notaryPool[0].txOpts.Value = notaryDeposit
+	smc.RegisterNotary(notaryPool[0].txOpts)
 	backend.Commit()
 
-	notary, _ := smc.NotaryRegistry(&bind.CallOpts{}, addr)
+	notary, _ := smc.NotaryRegistry(&bind.CallOpts{}, notaryPool[0].addr)
 	numNotaries, _ := smc.NotaryPoolLength(&bind.CallOpts{})
 
 	if !notary.Deposited {
@@ -272,8 +281,8 @@ func TestNotaryDeregisterThenRegister(t *testing.T) {
 	}
 
 	// Notary 0 deregisters.
-	txOpts = bind.NewKeyedTransactor(mainKey)
-	_, err := smc.DeregisterNotary(txOpts)
+	notaryPool[0].txOpts = bind.NewKeyedTransactor(notaryPool[0].privKey)
+	_, err := smc.DeregisterNotary(notaryPool[0].txOpts)
 	if err != nil {
 		t.Fatalf("Failed to deregister notary: %v", err)
 	}
@@ -285,7 +294,7 @@ func TestNotaryDeregisterThenRegister(t *testing.T) {
 	}
 
 	// Notary 0 re-registers again.
-	smc.RegisterNotary(txOpts)
+	smc.RegisterNotary(notaryPool[0].txOpts)
 	backend.Commit()
 
 	numNotaries, _ = smc.NotaryPoolLength(&bind.CallOpts{})
@@ -296,17 +305,16 @@ func TestNotaryDeregisterThenRegister(t *testing.T) {
 
 // TestNotaryRelease tests notary releases in a normal condition.
 func TestNotaryRelease(t *testing.T) {
-	addr := crypto.PubkeyToAddress(mainKey.PublicKey)
-	backend := backends.NewSimulatedBackend(core.GenesisAlloc{addr: {Balance: accountBalance2000Eth}})
-	txOpts := bind.NewKeyedTransactor(mainKey)
-	txOpts.Value = notaryDeposit
-	_, _, smc, _ := deploySMCContract(backend, mainKey)
+	notaryPool, genesis := initAccounts(1)
+	backend := backends.NewSimulatedBackend(genesis)
+	_, _, smc, _ := deploySMCContract(backend, notaryPool[0].privKey)
 
 	// Notary 0 registers.
-	smc.RegisterNotary(txOpts)
+	notaryPool[0].txOpts.Value = notaryDeposit
+	smc.RegisterNotary(notaryPool[0].txOpts)
 	backend.Commit()
 
-	notary, _ := smc.NotaryRegistry(&bind.CallOpts{}, addr)
+	notary, _ := smc.NotaryRegistry(&bind.CallOpts{}, notaryPool[0].addr)
 	numNotaries, _ := smc.NotaryPoolLength(&bind.CallOpts{})
 
 	if !notary.Deposited {
@@ -323,8 +331,8 @@ func TestNotaryRelease(t *testing.T) {
 	}
 
 	// Notary 0 deregisters.
-	txOpts = bind.NewKeyedTransactor(mainKey)
-	_, err := smc.DeregisterNotary(txOpts)
+	notaryPool[0].txOpts = bind.NewKeyedTransactor(notaryPool[0].privKey)
+	_, err := smc.DeregisterNotary(notaryPool[0].txOpts)
 	if err != nil {
 		t.Fatalf("Failed to deregister notary: %v", err)
 	}
@@ -341,13 +349,13 @@ func TestNotaryRelease(t *testing.T) {
 	}
 
 	// Notary 0 releases.
-	_, err = smc.ReleaseNotary(txOpts)
+	_, err = smc.ReleaseNotary(notaryPool[0].txOpts)
 	if err != nil {
 		t.Fatalf("Failed to release notary: %v", err)
 	}
 	backend.Commit()
 
-	notary, err = smc.NotaryRegistry(&bind.CallOpts{}, addr)
+	notary, err = smc.NotaryRegistry(&bind.CallOpts{}, notaryPool[0].addr)
 	if err != nil {
 		t.Fatalf("Can't get notary registry info: %v", err)
 	}
@@ -356,7 +364,7 @@ func TestNotaryRelease(t *testing.T) {
 		t.Errorf("Notary deposit flag should be false after released")
 	}
 
-	balance, err := backend.BalanceAt(ctx, addr, nil)
+	balance, err := backend.BalanceAt(ctx, notaryPool[0].addr, nil)
 	if err != nil {
 		t.Errorf("Can't get account balance, err: %s", err)
 	}
@@ -368,17 +376,16 @@ func TestNotaryRelease(t *testing.T) {
 
 // TestNotaryInstantRelease tests notary releases before lockup ends.
 func TestNotaryInstantRelease(t *testing.T) {
-	addr := crypto.PubkeyToAddress(mainKey.PublicKey)
-	backend := backends.NewSimulatedBackend(core.GenesisAlloc{addr: {Balance: accountBalance2000Eth}})
-	txOpts := bind.NewKeyedTransactor(mainKey)
-	txOpts.Value = notaryDeposit
-	_, _, smc, _ := deploySMCContract(backend, mainKey)
+	notaryPool, genesis := initAccounts(1)
+	backend := backends.NewSimulatedBackend(genesis)
+	_, _, smc, _ := deploySMCContract(backend, notaryPool[0].privKey)
 
 	// Notary 0 registers.
-	smc.RegisterNotary(txOpts)
+	notaryPool[0].txOpts.Value = notaryDeposit
+	smc.RegisterNotary(notaryPool[0].txOpts)
 	backend.Commit()
 
-	notary, _ := smc.NotaryRegistry(&bind.CallOpts{}, addr)
+	notary, _ := smc.NotaryRegistry(&bind.CallOpts{}, notaryPool[0].addr)
 	numNotaries, _ := smc.NotaryPoolLength(&bind.CallOpts{})
 
 	if !notary.Deposited {
@@ -395,8 +402,8 @@ func TestNotaryInstantRelease(t *testing.T) {
 	}
 
 	// Notary 0 deregisters.
-	txOpts = bind.NewKeyedTransactor(mainKey)
-	_, err := smc.DeregisterNotary(txOpts)
+	notaryPool[0].txOpts = bind.NewKeyedTransactor(notaryPool[0].privKey)
+	_, err := smc.DeregisterNotary(notaryPool[0].txOpts)
 	if err != nil {
 		t.Fatalf("Failed to deregister notary: %v", err)
 	}
@@ -408,10 +415,10 @@ func TestNotaryInstantRelease(t *testing.T) {
 	}
 
 	// Notary 0 tries to release before lockup ends.
-	_, err = smc.ReleaseNotary(txOpts)
+	_, err = smc.ReleaseNotary(notaryPool[0].txOpts)
 	backend.Commit()
 
-	notary, err = smc.NotaryRegistry(&bind.CallOpts{}, addr)
+	notary, err = smc.NotaryRegistry(&bind.CallOpts{}, notaryPool[0].addr)
 	if err != nil {
 		t.Fatalf("Can't get notary registry info: %v", err)
 	}
@@ -420,7 +427,7 @@ func TestNotaryInstantRelease(t *testing.T) {
 		t.Errorf("Notary deposit flag should be true before released")
 	}
 
-	balance, err := backend.BalanceAt(ctx, addr, nil)
+	balance, err := backend.BalanceAt(ctx, notaryPool[0].addr, nil)
 
 	if balance.Cmp(notaryDeposit) > 0 {
 		t.Errorf("Notary received deposit before lockup ends")
@@ -429,35 +436,20 @@ func TestNotaryInstantRelease(t *testing.T) {
 
 // TestCommitteeListsAreDifferent tests different shards have different notary committee.
 func TestCommitteeListsAreDifferent(t *testing.T) {
-	const notaryCount = 1000
-	var notaryPoolAddr [notaryCount]common.Address
-	var notaryPoolPrivKeys [notaryCount]*ecdsa.PrivateKey
-	var txOpts [notaryCount]*bind.TransactOpts
-	genesis := make(core.GenesisAlloc)
-
-	// initializes back end with 10000 accounts and each with 2000 eth balances.
-	for i := 0; i < notaryCount; i++ {
-		key, _ := crypto.GenerateKey()
-		notaryPoolPrivKeys[i] = key
-		notaryPoolAddr[i] = crypto.PubkeyToAddress(key.PublicKey)
-		txOpts[i] = bind.NewKeyedTransactor(key)
-		txOpts[i].Value = notaryDeposit
-		genesis[notaryPoolAddr[i]] = core.GenesisAccount{
-			Balance: accountBalance2000Eth,
-		}
-	}
-
+	notaryCount := 1000
+	notaryPool, genesis := initAccounts(notaryCount)
 	backend := backends.NewSimulatedBackend(genesis)
-	_, _, smc, _ := deploySMCContract(backend, notaryPoolPrivKeys[0])
+	_, _, smc, _ := deploySMCContract(backend, notaryPool[0].privKey)
 
 	// Register 1000 notaries to SMC.
 	for i := 0; i < notaryCount; i++ {
-		smc.RegisterNotary(txOpts[i])
+		notaryPool[i].txOpts.Value = notaryDeposit
+		smc.RegisterNotary(notaryPool[i].txOpts)
 		backend.Commit()
 	}
 
 	numNotaries, _ := smc.NotaryPoolLength(&bind.CallOpts{})
-	if numNotaries.Cmp(big.NewInt(notaryCount)) != 0 {
+	if numNotaries.Cmp(big.NewInt(int64(notaryCount))) != 0 {
 		t.Errorf("Incorrect count from notary pool. Want: 1000, Got: %v", numNotaries)
 	}
 
@@ -475,60 +467,43 @@ func TestCommitteeListsAreDifferent(t *testing.T) {
 // TestGetCommitteeWithNonMember tests unregistered notary tries to be in the committee.
 func TestGetCommitteeWithNonMember(t *testing.T) {
 	const notaryCount = 11
-	var notaryPoolAddr [notaryCount]common.Address
-	var notaryPoolPrivKeys [notaryCount]*ecdsa.PrivateKey
-	var txOpts [notaryCount]*bind.TransactOpts
-	genesis := make(core.GenesisAlloc)
-
-	// Initialize back end with 11 accounts and each with 2000 eth balances.
-	for i := 0; i < notaryCount; i++ {
-		key, _ := crypto.GenerateKey()
-		notaryPoolPrivKeys[i] = key
-		notaryPoolAddr[i] = crypto.PubkeyToAddress(key.PublicKey)
-		txOpts[i] = bind.NewKeyedTransactor(key)
-		txOpts[i].Value = notaryDeposit
-		genesis[notaryPoolAddr[i]] = core.GenesisAccount{
-			Balance: accountBalance2000Eth,
-		}
-	}
-
+	notaryPool, genesis := initAccounts(notaryCount)
 	backend := backends.NewSimulatedBackend(genesis)
-	_, _, smc, _ := deploySMCContract(backend, notaryPoolPrivKeys[0])
+	_, _, smc, _ := deploySMCContract(backend, notaryPool[0].privKey)
 
 	// Register 10 notaries to SMC, leave 1 address free.
 	for i := 0; i < 10; i++ {
-		smc.RegisterNotary(txOpts[i])
+		notaryPool[i].txOpts.Value = notaryDeposit
+		smc.RegisterNotary(notaryPool[i].txOpts)
 		backend.Commit()
 	}
 
 	numNotaries, _ := smc.NotaryPoolLength(&bind.CallOpts{})
 	if numNotaries.Cmp(big.NewInt(10)) != 0 {
-		t.Fatalf("Incorrect count from notary pool. Want: 135, Got: %v", numNotaries)
+		t.Fatalf("Incorrect count from notary pool. Want: 10, Got: %v", numNotaries)
 	}
 
 	// Verify the unregistered account is not in the notary pool list.
 	for i := 0; i < 10; i++ {
 		addr, _ := smc.GetNotaryInCommittee(&bind.CallOpts{}, big.NewInt(0))
-		if notaryPoolAddr[10].String() == addr.String() {
-			t.Errorf("Account %s is not a notary", notaryPoolAddr[10].String())
+		if notaryPool[10].addr == addr {
+			t.Errorf("Account %s is not a notary", notaryPool[10].addr.String())
 		}
 	}
-
 }
 
 // TestGetCommitteeWithinSamePeriod tests notary registers and samples within the same period
 func TestGetCommitteeWithinSamePeriod(t *testing.T) {
-	addr := crypto.PubkeyToAddress(mainKey.PublicKey)
-	backend := backends.NewSimulatedBackend(core.GenesisAlloc{addr: {Balance: accountBalance2000Eth}})
-	txOpts := bind.NewKeyedTransactor(mainKey)
-	txOpts.Value = notaryDeposit
-	_, _, smc, _ := deploySMCContract(backend, mainKey)
+	notaryPool, genesis := initAccounts(1)
+	backend := backends.NewSimulatedBackend(genesis)
+	_, _, smc, _ := deploySMCContract(backend, notaryPool[0].privKey)
 
 	// Notary 0 registers.
-	smc.RegisterNotary(txOpts)
+	notaryPool[0].txOpts.Value = notaryDeposit
+	smc.RegisterNotary(notaryPool[0].txOpts)
 	backend.Commit()
 
-	notary, _ := smc.NotaryRegistry(&bind.CallOpts{}, addr)
+	notary, _ := smc.NotaryRegistry(&bind.CallOpts{}, notaryPool[0].addr)
 	numNotaries, _ := smc.NotaryPoolLength(&bind.CallOpts{})
 
 	if !notary.Deposited {
@@ -542,7 +517,7 @@ func TestGetCommitteeWithinSamePeriod(t *testing.T) {
 	// Notary 0 samples for itself within the same period after registration
 	sampledAddr, _ := smc.GetNotaryInCommittee(&bind.CallOpts{}, big.NewInt(0))
 
-	if addr != sampledAddr {
+	if notaryPool[0].addr != sampledAddr {
 		t.Errorf("Unable to sample notary address within same period of registration, got addr: %v", sampledAddr)
 	}
 }
@@ -550,29 +525,14 @@ func TestGetCommitteeWithinSamePeriod(t *testing.T) {
 // TestGetCommitteeAfterDeregisters tests notary tries to be in committee after deregistered.
 func TestGetCommitteeAfterDeregisters(t *testing.T) {
 	const notaryCount = 10
-	var notaryPoolAddr [notaryCount]common.Address
-	var notaryPoolPrivKeys [notaryCount]*ecdsa.PrivateKey
-	var txOpts [notaryCount]*bind.TransactOpts
-	genesis := make(core.GenesisAlloc)
-
-	// Initialize back end with 10 accounts and each with 2000 eth balances.
-	for i := 0; i < notaryCount; i++ {
-		key, _ := crypto.GenerateKey()
-		notaryPoolPrivKeys[i] = key
-		notaryPoolAddr[i] = crypto.PubkeyToAddress(key.PublicKey)
-		txOpts[i] = bind.NewKeyedTransactor(key)
-		txOpts[i].Value = notaryDeposit
-		genesis[notaryPoolAddr[i]] = core.GenesisAccount{
-			Balance: accountBalance2000Eth,
-		}
-	}
-
+	notaryPool, genesis := initAccounts(notaryCount)
 	backend := backends.NewSimulatedBackend(genesis)
-	_, _, smc, _ := deploySMCContract(backend, notaryPoolPrivKeys[0])
+	_, _, smc, _ := deploySMCContract(backend, notaryPool[0].privKey)
 
 	// Register 10 notaries to SMC.
 	for i := 0; i < 10; i++ {
-		smc.RegisterNotary(txOpts[i])
+		notaryPool[i].txOpts.Value = notaryDeposit
+		smc.RegisterNotary(notaryPool[i].txOpts)
 		backend.Commit()
 	}
 
@@ -582,8 +542,8 @@ func TestGetCommitteeAfterDeregisters(t *testing.T) {
 	}
 
 	// Deregister notary 0 from SMC.
-	txOpts[0].Value = big.NewInt(0)
-	smc.DeregisterNotary(txOpts[0])
+	notaryPool[0].txOpts.Value = big.NewInt(0)
+	smc.DeregisterNotary(notaryPool[0].txOpts)
 	backend.Commit()
 
 	numNotaries, _ = smc.NotaryPoolLength(&bind.CallOpts{})
@@ -594,18 +554,17 @@ func TestGetCommitteeAfterDeregisters(t *testing.T) {
 	// Verify degistered notary 0 is not in the notary pool list.
 	for i := 0; i < 10; i++ {
 		addr, _ := smc.GetNotaryInCommittee(&bind.CallOpts{}, big.NewInt(0))
-		if notaryPoolAddr[0].String() == addr.String() {
-			t.Errorf("Account %s is not a notary", notaryPoolAddr[0].String())
+		if notaryPool[0].addr == addr {
+			t.Errorf("Account %s is not a notary", notaryPool[0].addr.String())
 		}
 	}
 }
 
 // TestNormalAddHeader tests proposer add header in normal condition.
 func TestNormalAddHeader(t *testing.T) {
-	addr := crypto.PubkeyToAddress(mainKey.PublicKey)
-	backend := backends.NewSimulatedBackend(core.GenesisAlloc{addr: {Balance: accountBalance2000Eth}})
-	txOpts := bind.NewKeyedTransactor(mainKey)
-	_, _, smc, _ := deploySMCContract(backend, mainKey)
+	notaryPool, genesis := initAccounts(1)
+	backend := backends.NewSimulatedBackend(genesis)
+	_, _, smc, _ := deploySMCContract(backend, notaryPool[0].privKey)
 
 	// Fast forward to the next period to submit header. Period 1.
 	for i := 0; i < int(sharding.PeriodLength); i++ {
@@ -616,7 +575,7 @@ func TestNormalAddHeader(t *testing.T) {
 	period1 := big.NewInt(1)
 	shard0 := big.NewInt(0)
 	chunkRoot := [32]byte{'A'}
-	_, err := smc.AddHeader(txOpts, shard0, period1, chunkRoot)
+	_, err := smc.AddHeader(notaryPool[0].txOpts, shard0, period1, chunkRoot)
 	if err != nil {
 		t.Fatalf("Proposer adds header failed: %v", err)
 	}
@@ -643,7 +602,7 @@ func TestNormalAddHeader(t *testing.T) {
 	// Proposer adds header consists shard 0, period 2 and chunkroot 0xB.
 	period2 := big.NewInt(2)
 	chunkRoot = [32]byte{'B'}
-	_, err = smc.AddHeader(txOpts, shard0, period2, chunkRoot)
+	_, err = smc.AddHeader(notaryPool[0].txOpts, shard0, period2, chunkRoot)
 	if err != nil {
 		t.Fatalf("Proposer adds header failed: %v", err)
 	}
@@ -662,7 +621,7 @@ func TestNormalAddHeader(t *testing.T) {
 	// Proposer adds header consists shard 1, period 2 and chunkroot 0xC.
 	shard1 := big.NewInt(1)
 	chunkRoot = [32]byte{'C'}
-	_, err = smc.AddHeader(txOpts, shard1, period2, chunkRoot)
+	_, err = smc.AddHeader(notaryPool[0].txOpts, shard1, period2, chunkRoot)
 	backend.Commit()
 
 	p, err = smc.LastSubmittedCollation(&bind.CallOpts{}, shard1)
@@ -678,10 +637,9 @@ func TestNormalAddHeader(t *testing.T) {
 
 // TestAddTwoHeadersAtSamePeriod tests we can't add two headers within the same period.
 func TestAddTwoHeadersAtSamePeriod(t *testing.T) {
-	addr := crypto.PubkeyToAddress(mainKey.PublicKey)
-	backend := backends.NewSimulatedBackend(core.GenesisAlloc{addr: {Balance: accountBalance2000Eth}})
-	txOpts := bind.NewKeyedTransactor(mainKey)
-	_, _, smc, _ := deploySMCContract(backend, mainKey)
+	notaryPool, genesis := initAccounts(1)
+	backend := backends.NewSimulatedBackend(genesis)
+	_, _, smc, _ := deploySMCContract(backend, notaryPool[0].privKey)
 
 	// Fast forward to the next period to submit header. Period 1.
 	for i := 0; i < int(sharding.PeriodLength); i++ {
@@ -692,7 +650,7 @@ func TestAddTwoHeadersAtSamePeriod(t *testing.T) {
 	period1 := big.NewInt(1)
 	shard0 := big.NewInt(0)
 	chunkRoot := [32]byte{'A'}
-	_, err := smc.AddHeader(txOpts, shard0, period1, chunkRoot)
+	_, err := smc.AddHeader(notaryPool[0].txOpts, shard0, period1, chunkRoot)
 	if err != nil {
 		t.Fatalf("Proposer adds header failed: %v", err)
 	}
@@ -709,7 +667,7 @@ func TestAddTwoHeadersAtSamePeriod(t *testing.T) {
 
 	// Proposer attempts to add another header chunkroot 0xB on the same period for the same shard.
 	chunkRoot = [32]byte{'B'}
-	_, err = smc.AddHeader(txOpts, shard0, period1, chunkRoot)
+	_, err = smc.AddHeader(notaryPool[0].txOpts, shard0, period1, chunkRoot)
 	if err == nil {
 		t.Errorf("Proposer is not allowed to add 2 headers within same period")
 	}
@@ -717,10 +675,9 @@ func TestAddTwoHeadersAtSamePeriod(t *testing.T) {
 
 // TestAddHeadersAtWrongPeriod tests proposer adds header in the wrong period.
 func TestAddHeadersAtWrongPeriod(t *testing.T) {
-	addr := crypto.PubkeyToAddress(mainKey.PublicKey)
-	backend := backends.NewSimulatedBackend(core.GenesisAlloc{addr: {Balance: accountBalance2000Eth}})
-	txOpts := bind.NewKeyedTransactor(mainKey)
-	_, _, smc, _ := deploySMCContract(backend, mainKey)
+	notaryPool, genesis := initAccounts(1)
+	backend := backends.NewSimulatedBackend(genesis)
+	_, _, smc, _ := deploySMCContract(backend, notaryPool[0].privKey)
 
 	// Fast forward to the next period to submit header. Period 1.
 	for i := 0; i < int(sharding.PeriodLength); i++ {
@@ -732,7 +689,7 @@ func TestAddHeadersAtWrongPeriod(t *testing.T) {
 	shard0 := big.NewInt(0)
 	chunkRoot := [32]byte{'A'}
 	chunkRootEmpty := [32]byte{}
-	_, err := smc.AddHeader(txOpts, shard0, period0, chunkRoot)
+	_, err := smc.AddHeader(notaryPool[0].txOpts, shard0, period0, chunkRoot)
 	if err == nil {
 		t.Errorf("Proposer adds header at wrong period should have failed")
 	}
@@ -744,7 +701,7 @@ func TestAddHeadersAtWrongPeriod(t *testing.T) {
 
 	// Proposer adds header at wrong period, shard 0, period 2 and chunkroot 0xA.
 	period2 := big.NewInt(2)
-	_, err = smc.AddHeader(txOpts, shard0, period2, chunkRoot)
+	_, err = smc.AddHeader(notaryPool[0].txOpts, shard0, period2, chunkRoot)
 	if err == nil {
 		t.Errorf("Proposer adds header at wrong period should have failed")
 	}
@@ -756,7 +713,7 @@ func TestAddHeadersAtWrongPeriod(t *testing.T) {
 
 	// Proposer adds header at correct period, shard 0, period 1 and chunkroot 0xA.
 	period1 := big.NewInt(1)
-	_, err = smc.AddHeader(txOpts, shard0, period1, chunkRoot)
+	_, err = smc.AddHeader(notaryPool[0].txOpts, shard0, period1, chunkRoot)
 	if err != nil {
 		t.Fatalf("Proposer adds header failed: %v", err)
 	}
@@ -769,14 +726,13 @@ func TestAddHeadersAtWrongPeriod(t *testing.T) {
 
 // TestSubmitVote tests notary submit votes in normal condition.
 func TestSubmitVote(t *testing.T) {
-	addr := crypto.PubkeyToAddress(mainKey.PublicKey)
-	backend := backends.NewSimulatedBackend(core.GenesisAlloc{addr: {Balance: accountBalance2000Eth}})
-	txOpts := bind.NewKeyedTransactor(mainKey)
-	txOpts.Value = notaryDeposit
-	_, _, smc, _ := deploySMCContract(backend, mainKey)
+	notaryPool, genesis := initAccounts(1)
+	backend := backends.NewSimulatedBackend(genesis)
+	_, _, smc, _ := deploySMCContract(backend, notaryPool[0].privKey)
 
 	// Notary 0 registers.
-	smc.RegisterNotary(txOpts)
+	notaryPool[0].txOpts.Value = notaryDeposit
+	smc.RegisterNotary(notaryPool[0].txOpts)
 	backend.Commit()
 
 	// Fast forward to the next period to submit header. Period 1.
@@ -789,8 +745,8 @@ func TestSubmitVote(t *testing.T) {
 	shard0 := big.NewInt(0)
 	index0 := big.NewInt(0)
 	chunkRoot := [32]byte{'A'}
-	txOpts.Value = big.NewInt(0)
-	_, err := smc.AddHeader(txOpts, shard0, period1, chunkRoot)
+	notaryPool[0].txOpts.Value = big.NewInt(0)
+	_, err := smc.AddHeader(notaryPool[0].txOpts, shard0, period1, chunkRoot)
 	if err != nil {
 		t.Fatalf("Proposer adds header failed: %v", err)
 	}
@@ -805,7 +761,7 @@ func TestSubmitVote(t *testing.T) {
 		t.Errorf("Incorrect notary vote count, want: 0, got: %v", c)
 	}
 
-	_, err = smc.SubmitVote(txOpts, shard0, period1, index0, chunkRoot)
+	_, err = smc.SubmitVote(notaryPool[0].txOpts, shard0, period1, index0, chunkRoot)
 	backend.Commit()
 	if err != nil {
 		t.Fatalf("Notary submits vote failed: %v", err)
@@ -846,14 +802,13 @@ func TestSubmitVote(t *testing.T) {
 
 // TestSubmitVoteTwice tests notary tries to submit same vote twice.
 func TestSubmitVoteTwice(t *testing.T) {
-	addr := crypto.PubkeyToAddress(mainKey.PublicKey)
-	backend := backends.NewSimulatedBackend(core.GenesisAlloc{addr: {Balance: accountBalance2000Eth}})
-	txOpts := bind.NewKeyedTransactor(mainKey)
-	txOpts.Value = notaryDeposit
-	_, _, smc, _ := deploySMCContract(backend, mainKey)
+	notaryPool, genesis := initAccounts(1)
+	backend := backends.NewSimulatedBackend(genesis)
+	_, _, smc, _ := deploySMCContract(backend, notaryPool[0].privKey)
 
 	// Notary 0 registers.
-	smc.RegisterNotary(txOpts)
+	notaryPool[0].txOpts.Value = notaryDeposit
+	smc.RegisterNotary(notaryPool[0].txOpts)
 	backend.Commit()
 
 	// Fast forward to the next period to submit header. Period 1.
@@ -866,15 +821,15 @@ func TestSubmitVoteTwice(t *testing.T) {
 	shard0 := big.NewInt(0)
 	index0 := big.NewInt(0)
 	chunkRoot := [32]byte{'A'}
-	txOpts.Value = big.NewInt(0)
-	_, err := smc.AddHeader(txOpts, shard0, period1, chunkRoot)
+	notaryPool[0].txOpts.Value = big.NewInt(0)
+	_, err := smc.AddHeader(notaryPool[0].txOpts, shard0, period1, chunkRoot)
 	if err != nil {
 		t.Fatalf("Proposer adds header failed: %v", err)
 	}
 	backend.Commit()
 
 	// Notary 0 votes on header.
-	smc.SubmitVote(txOpts, shard0, period1, index0, chunkRoot)
+	smc.SubmitVote(notaryPool[0].txOpts, shard0, period1, index0, chunkRoot)
 	backend.Commit()
 
 	// Check notary 0's vote is correctly casted.
@@ -884,7 +839,7 @@ func TestSubmitVoteTwice(t *testing.T) {
 	}
 
 	// Notary 0 votes on header again, it should fail.
-	_, err = smc.SubmitVote(txOpts, shard0, period1, index0, chunkRoot)
+	_, err = smc.SubmitVote(notaryPool[0].txOpts, shard0, period1, index0, chunkRoot)
 	if err == nil {
 		t.Errorf("notary voting twice should have failed")
 	}
@@ -899,11 +854,9 @@ func TestSubmitVoteTwice(t *testing.T) {
 
 // TestSubmitVoteByNonEligibleNotary tests a non-eligible notary tries to submit vote.
 func TestSubmitVoteByNonEligibleNotary(t *testing.T) {
-	addr := crypto.PubkeyToAddress(mainKey.PublicKey)
-	backend := backends.NewSimulatedBackend(core.GenesisAlloc{addr: {Balance: accountBalance2000Eth}})
-	txOpts := bind.NewKeyedTransactor(mainKey)
-	txOpts.Value = notaryDeposit
-	_, _, smc, _ := deploySMCContract(backend, mainKey)
+	notaryPool, genesis := initAccounts(1)
+	backend := backends.NewSimulatedBackend(genesis)
+	_, _, smc, _ := deploySMCContract(backend, notaryPool[0].privKey)
 
 	// Fast forward to the next period to submit header. Period 1.
 	for i := 0; i < int(sharding.PeriodLength); i++ {
@@ -915,15 +868,15 @@ func TestSubmitVoteByNonEligibleNotary(t *testing.T) {
 	shard0 := big.NewInt(0)
 	index0 := big.NewInt(0)
 	chunkRoot := [32]byte{'A'}
-	txOpts.Value = big.NewInt(0)
-	_, err := smc.AddHeader(txOpts, shard0, period1, chunkRoot)
+	notaryPool[0].txOpts.Value = big.NewInt(0)
+	_, err := smc.AddHeader(notaryPool[0].txOpts, shard0, period1, chunkRoot)
 	if err != nil {
 		t.Fatalf("Proposer adds header failed: %v", err)
 	}
 	backend.Commit()
 
 	// Unregistered Notary 0 votes on header, it should fail.
-	_, err = smc.SubmitVote(txOpts, shard0, period1, index0, chunkRoot)
+	_, err = smc.SubmitVote(notaryPool[0].txOpts, shard0, period1, index0, chunkRoot)
 	backend.Commit()
 	if err == nil {
 		t.Errorf("Non registered notary submits vote should have failed")
@@ -936,14 +889,13 @@ func TestSubmitVoteByNonEligibleNotary(t *testing.T) {
 
 // TestSubmitVoteWithOutAHeader tests a notary tries to submit vote before header gets added.
 func TestSubmitVoteWithOutAHeader(t *testing.T) {
-	addr := crypto.PubkeyToAddress(mainKey.PublicKey)
-	backend := backends.NewSimulatedBackend(core.GenesisAlloc{addr: {Balance: accountBalance2000Eth}})
-	txOpts := bind.NewKeyedTransactor(mainKey)
-	txOpts.Value = notaryDeposit
-	_, _, smc, _ := deploySMCContract(backend, mainKey)
+	notaryPool, genesis := initAccounts(1)
+	backend := backends.NewSimulatedBackend(genesis)
+	_, _, smc, _ := deploySMCContract(backend, notaryPool[0].privKey)
 
 	// Notary 0 registers.
-	smc.RegisterNotary(txOpts)
+	notaryPool[0].txOpts.Value = notaryDeposit
+	smc.RegisterNotary(notaryPool[0].txOpts)
 	backend.Commit()
 
 	// Fast forward to the next period to submit header. Period 1.
@@ -956,10 +908,10 @@ func TestSubmitVoteWithOutAHeader(t *testing.T) {
 	shard0 := big.NewInt(0)
 	index0 := big.NewInt(0)
 	chunkRoot := [32]byte{'A'}
-	txOpts.Value = big.NewInt(0)
+	notaryPool[0].txOpts.Value = big.NewInt(0)
 
 	// Notary 0 votes on header, it should fail because no header has added.
-	_, err := smc.SubmitVote(txOpts, shard0, period1, index0, chunkRoot)
+	_, err := smc.SubmitVote(notaryPool[0].txOpts, shard0, period1, index0, chunkRoot)
 	if err == nil {
 		t.Errorf("Notary votes should have failed due to missing header")
 	}
@@ -974,14 +926,13 @@ func TestSubmitVoteWithOutAHeader(t *testing.T) {
 
 // TestSubmitVoteWithInvalidArgs tests notary submits vote using wrong chunkroot and period.
 func TestSubmitVoteWithInvalidArgs(t *testing.T) {
-	addr := crypto.PubkeyToAddress(mainKey.PublicKey)
-	backend := backends.NewSimulatedBackend(core.GenesisAlloc{addr: {Balance: accountBalance2000Eth}})
-	txOpts := bind.NewKeyedTransactor(mainKey)
-	txOpts.Value = notaryDeposit
-	_, _, smc, _ := deploySMCContract(backend, mainKey)
+	notaryPool, genesis := initAccounts(1)
+	backend := backends.NewSimulatedBackend(genesis)
+	_, _, smc, _ := deploySMCContract(backend, notaryPool[0].privKey)
 
-	// Notary 0 registers
-	smc.RegisterNotary(txOpts)
+	// Notary 0 registers.
+	notaryPool[0].txOpts.Value = notaryDeposit
+	smc.RegisterNotary(notaryPool[0].txOpts)
 	backend.Commit()
 
 	// Fast forward to the next period to submit header. Period 1.
@@ -994,8 +945,8 @@ func TestSubmitVoteWithInvalidArgs(t *testing.T) {
 	shard0 := big.NewInt(0)
 	index0 := big.NewInt(0)
 	chunkRoot := [32]byte{'A'}
-	txOpts.Value = big.NewInt(0)
-	_, err := smc.AddHeader(txOpts, shard0, period1, chunkRoot)
+	notaryPool[0].txOpts.Value = big.NewInt(0)
+	_, err := smc.AddHeader(notaryPool[0].txOpts, shard0, period1, chunkRoot)
 	if err != nil {
 		t.Fatalf("Proposer adds header failed: %v", err)
 	}
@@ -1003,14 +954,14 @@ func TestSubmitVoteWithInvalidArgs(t *testing.T) {
 
 	// Notary voting with incorrect period.
 	period2 := big.NewInt(2)
-	_, err = smc.SubmitVote(txOpts, shard0, period2, index0, chunkRoot)
+	_, err = smc.SubmitVote(notaryPool[0].txOpts, shard0, period2, index0, chunkRoot)
 	if err == nil {
 		t.Errorf("Notary votes should have failed due to incorrect period")
 	}
 
 	// Notary voting with incorrect chunk root.
 	chunkRootWrong := [32]byte{'B'}
-	_, err = smc.SubmitVote(txOpts, shard0, period1, index0, chunkRootWrong)
+	_, err = smc.SubmitVote(notaryPool[0].txOpts, shard0, period1, index0, chunkRootWrong)
 	if err == nil {
 		t.Errorf("Notary votes should have failed due to incorrect chunk root")
 	}


### PR DESCRIPTION
## What was wrong?
`sharding_manager_test.go` is getting to be too long, there's a bunch of reusable code that could be packaged into a helper functions. As `sharding_manager` gains more functionality and complexity, it's important to design our tests with modularity and testability in mind.

## How was it fixed?
Refactored most used SMC tx called `initializeAccount`, `registerNotary`, `addHeader`, `submitVote` into helper functions. Verified all the tests still passed.