### PR TITLE
Serialize Function Should be Pure

### DIFF
--- a/sharding/collation.go
+++ b/sharding/collation.go
@@ -129,7 +129,7 @@ func ConvertBackToTx(rawBlobs []utils.RawBlob) ([]*types.Transaction, error) {
 
 }
 
-// Serialize method serializes the input tx
+// SerializeTxToBlob method serializes the input tx
 // and returns the blobs in byte array.
 func SerializeTxToBlob(txs []*types.Transaction) ([]byte, error) {
 

--- a/sharding/collation.go
+++ b/sharding/collation.go
@@ -129,9 +129,9 @@ func ConvertBackToTx(rawBlobs []utils.RawBlob) ([]*types.Transaction, error) {
 
 }
 
-// Serialize method serializes the input transactions
-// and returns the chunks in byte arrays.
-func Serialize(txs []*types.Transaction) ([]byte, error) {
+// Serialize method serializes the input tx
+// and returns the blobs in byte array.
+func SerializeTxToBlob(txs []*types.Transaction) ([]byte, error) {
 
 	blobs := make([]*utils.RawBlob, len(txs))
 	for i := 0; i < len(txs); i++ {
@@ -153,8 +153,9 @@ func Serialize(txs []*types.Transaction) ([]byte, error) {
 	return serializedTx, nil
 }
 
-// Deserialize takes a byte array and converts its back to its original transactions.
-func Deserialize(serialisedBlob []byte) (*[]*types.Transaction, error) {
+// DeserializeBlobToTx takes byte array blob and converts it back
+// to original txs and returns the txs in tx array.
+func DeserializeBlobToTx(serialisedBlob []byte) (*[]*types.Transaction, error) {
 
 	deserializedBlobs, err := utils.Deserialize(serialisedBlob)
 	if err != nil {

--- a/sharding/collation.go
+++ b/sharding/collation.go
@@ -111,26 +111,6 @@ func (c *Collation) CalculateChunkRoot() {
 	c.header.data.ChunkRoot = &chunkRoot
 }
 
-// CreateRawBlobs creates raw blobs from transactions.
-func (c Collation) CreateRawBlobs() ([]*utils.RawBlob, error) {
-
-	// It does not skip evm execution by default
-	blobs := make([]*utils.RawBlob, len(c.transactions))
-	for i := 0; i < len(c.transactions); i++ {
-
-		err := error(nil)
-		blobs[i], err = utils.NewRawBlob(c.transactions[i], false)
-
-		if err != nil {
-			return nil, fmt.Errorf("Creation of raw blobs from transactions failed: %v", err)
-		}
-
-	}
-
-	return blobs, nil
-
-}
-
 // ConvertBackToTx converts raw blobs back to their original transactions.
 func ConvertBackToTx(rawBlobs []utils.RawBlob) ([]*types.Transaction, error) {
 
@@ -149,29 +129,28 @@ func ConvertBackToTx(rawBlobs []utils.RawBlob) ([]*types.Transaction, error) {
 
 }
 
-// Serialize method  serializes the collation body to a byte array.
-func (c *Collation) Serialize() ([]byte, error) {
+// Serialize method serializes the input transactions
+// and returns the chunks in byte arrays.
+func Serialize(txs []*types.Transaction) ([]byte, error) {
 
-	blobs, err := c.CreateRawBlobs()
-
-	if err != nil {
-		return nil, fmt.Errorf("%v", err)
+	blobs := make([]*utils.RawBlob, len(txs))
+	for i := 0; i < len(txs); i++ {
+		err := error(nil)
+		blobs[i], err = utils.NewRawBlob(txs[i], false)
+		if err != nil {
+			return nil, fmt.Errorf("%v", err)
+		}
 	}
-
 	serializedTx, err := utils.Serialize(blobs)
-
 	if err != nil {
 		return nil, fmt.Errorf("%v", err)
 	}
 
 	if int64(len(serializedTx)) > collationSizelimit {
-
 		return nil, fmt.Errorf("The serialized body exceeded the collation size limit: %v", serializedTx)
-
 	}
 
 	return serializedTx, nil
-
 }
 
 // Deserialize takes a byte array and converts its back to its original transactions.

--- a/sharding/collation_test.go
+++ b/sharding/collation_test.go
@@ -56,7 +56,7 @@ func TestSerialize_Deserialize(t *testing.T) {
 
 	tx := c.transactions
 
-	results, err := c.Serialize()
+	results, err := Serialize(tx)
 
 	if err != nil {
 		t.Errorf("Unable to Serialize transactions, %v", err)

--- a/sharding/collation_test.go
+++ b/sharding/collation_test.go
@@ -56,13 +56,13 @@ func TestSerialize_Deserialize(t *testing.T) {
 
 	tx := c.transactions
 
-	results, err := Serialize(tx)
+	results, err := SerializeTxToBlob(tx)
 
 	if err != nil {
 		t.Errorf("Unable to Serialize transactions, %v", err)
 	}
 
-	deserializedTxs, err := Deserialize(results)
+	deserializedTxs, err := DeserializeBlobToTx(results)
 
 	if err != nil {
 		t.Errorf("Unable to deserialize collation body, %v", err)


### PR DESCRIPTION
## What was wrong?
Collation serializer function requires a point receiver, it should just be a pure function. See #134 

## How it was fixed?
I updated collation serializer function to be a pure function so we can generate the data (header, body, txs) upfront to construct a collation. And I verified this did not break the existing tests