### PR TITLE
Benchmarking Serializer

### DIFF
--- a/sharding/collation_test.go
+++ b/sharding/collation_test.go
@@ -130,7 +130,7 @@ func makeTxWithGasLimit(gl uint64) *types.Transaction {
 
 // BENCHMARK TESTS
 
-// Helper function to generate test that completes round trip transaction tests for a specific number of transactions.
+// Helper function to generate test that completes round trip serialization tests for a specific number of transactions.
 func runBenchTest(b *testing.B, numTransactions int) {
 	var txs []*types.Transaction
 	for i := 0; i < 10; i++ {

--- a/sharding/collation_test.go
+++ b/sharding/collation_test.go
@@ -2,6 +2,7 @@ package sharding
 
 import (
 	"bytes"
+	"crypto/rand"
 	"math/big"
 	"reflect"
 	"testing"
@@ -125,4 +126,39 @@ func TestSerialize_Deserialize(t *testing.T) {
 
 func makeTxWithGasLimit(gl uint64) *types.Transaction {
 	return types.NewTransaction(0 /*nonce*/, common.HexToAddress("0x0") /*to*/, nil /*amount*/, gl, nil /*gasPrice*/, nil /*data*/)
+}
+
+// BENCHMARK TESTS
+
+// Helper function to generate test that completes round trip transaction tests for a specific number of transactions.
+func runBenchTest(b *testing.B, numTransactions int) {
+	var txs []*types.Transaction
+	for i := 0; i < 10; i++ {
+		data := make([]byte, 650)
+		rand.Read(data)
+		txs = append(txs, types.NewTransaction(0 /*nonce*/, common.HexToAddress("0x0") /*to*/, nil /*amount*/, 0 /*gasLimit*/, nil /*gasPrice*/, data))
+	}
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		results, _ := SerializeTxToBlob(txs)
+		_, _ = DeserializeBlobToTx(results)
+	}
+
+}
+
+func BenchmarkSerialization10(b *testing.B) {
+	runBenchTest(b, 10)
+}
+
+func BenchmarkSerialization100(b *testing.B) {
+	runBenchTest(b, 100)
+}
+
+func BenchmarkSerialization1000(b *testing.B) {
+	runBenchTest(b, 1000)
+}
+
+func BenchmarkSerialization10000(b *testing.B) {
+	runBenchTest(b, 10000)
 }

--- a/sharding/collation_test.go
+++ b/sharding/collation_test.go
@@ -133,7 +133,7 @@ func makeTxWithGasLimit(gl uint64) *types.Transaction {
 // Helper function to generate test that completes round trip serialization tests for a specific number of transactions.
 func runBenchTest(b *testing.B, numTransactions int) {
 	var txs []*types.Transaction
-	for i := 0; i < 10; i++ {
+	for i := 0; i < numTransactions; i++ {
 		data := make([]byte, 650)
 		rand.Read(data)
 		txs = append(txs, types.NewTransaction(0 /*nonce*/, common.HexToAddress("0x0") /*to*/, nil /*amount*/, 0 /*gasLimit*/, nil /*gasPrice*/, data))


### PR DESCRIPTION
Initial results:

```
goos: linux
goarch: amd64
pkg: github.com/ethereum/go-ethereum/sharding
BenchmarkSerialization10-4                 20000             84624 ns/op           97347 B/op        565 allocs/op
BenchmarkSerialization100-4                 2000            820836 ns/op          994422 B/op       5528 allocs/op
BenchmarkSerialization1000-4                 200           8076776 ns/op        10630373 B/op      55047 allocs/op
BenchmarkSerialization10000-4                  5         242064047 ns/op        244503252 B/op    350102 allocs/op
PASS
ok      github.com/ethereum/go-ethereum/sharding        9.118s
```

Here's a comparison against other protocols:

Protocol Buffers Marshal: *819 ns/op*
Protocol Buffers Unmarshal: *1163 ns/op*
JSON Marshal: *3316 ns/op*
JSON Unmarshal: *7196 ns/op*
XML Marshal: *9248 ns/op*
XML Unmarshal: *30485 ns/op*
[source](https://medium.com/@shijuvar/benchmarking-protocol-buffers-json-and-xml-in-go-57fa89b8525)

Building off of #136

I'm wondering how much of this is RLP and how much of it is our encoding... To be answered in #139  

We should be at least better than XML so I hope to find some improvements :)  