### PR TITLE
Set Gometallinter Deadline to 10 Minutes 

### DIFF
--- a/build/ci.go
+++ b/build/ci.go
@@ -338,6 +338,7 @@ func doLint(cmdline []string) {
 		"--enable=misspell",
 		"--enable=goconst",
 		"--min-occurrences=6", // for goconst
+		"--deadline=10m",
 	}
 	build.MustRunCommand(filepath.Join(GOBIN, "gometalinter.v2"), append(configs, packages...)...)
 


### PR DESCRIPTION
Linter in Travis has failed due to following:
> WARNING: deadline exceeded by linter goimports (try increasing --deadline)
> WARNING: deadline exceeded by linter varcheck (try increasing --deadline)
> WARNING: deadline exceeded by linter vet (try increasing --deadline)

Set Gometallinter deadline to 10 mins so it doesn't time out and cause Travis to fail