### PR TITLE
Serialization Perf

### DIFF
--- a/sharding/collation.go
+++ b/sharding/collation.go
@@ -111,7 +111,7 @@ func (c *Collation) CalculateChunkRoot() {
 	c.header.data.ChunkRoot = &chunkRoot
 }
 
-// Serializes transactions into RawBlobs. This step encodes transactions uses RLP encoding
+// convertTxToRawBlob transactions into RawBlobs. This step encodes transactions uses RLP encoding
 func convertTxToRawBlob(txs []*types.Transaction) ([]*utils.RawBlob, error) {
 	blobs := make([]*utils.RawBlob, len(txs))
 	for i := 0; i < len(txs); i++ {
@@ -124,7 +124,7 @@ func convertTxToRawBlob(txs []*types.Transaction) ([]*utils.RawBlob, error) {
 	return blobs, nil
 }
 
-// Serializes transactions using two steps. First performs RLP encoding, and then blob encoding.
+// SerializeTxToBlob converts transactions using two steps. First performs RLP encoding, and then blob encoding.
 func SerializeTxToBlob(txs []*types.Transaction) ([]byte, error) {
 	blobs, err := convertTxToRawBlob(txs)
 	if err != nil {
@@ -143,7 +143,7 @@ func SerializeTxToBlob(txs []*types.Transaction) ([]byte, error) {
 	return serializedTx, nil
 }
 
-// ConvertBackToTx converts raw blobs back to their original transactions.
+// convertRawBlobToTx converts raw blobs back to their original transactions.
 func convertRawBlobToTx(rawBlobs []utils.RawBlob) ([]*types.Transaction, error) {
 	blobs := make([]*types.Transaction, len(rawBlobs))
 

--- a/sharding/collation.go
+++ b/sharding/collation.go
@@ -118,7 +118,7 @@ func convertTxToRawBlob(txs []*types.Transaction) ([]*utils.RawBlob, error) {
 		err := error(nil)
 		blobs[i], err = utils.NewRawBlob(txs[i], false)
 		if err != nil {
-			return nil, fmt.Errorf("%v", err)
+			return nil, err
 		}
 	}
 	return blobs, nil
@@ -128,12 +128,12 @@ func convertTxToRawBlob(txs []*types.Transaction) ([]*utils.RawBlob, error) {
 func SerializeTxToBlob(txs []*types.Transaction) ([]byte, error) {
 	blobs, err := convertTxToRawBlob(txs)
 	if err != nil {
-		return nil, fmt.Errorf("%v", err)
+		return nil, err
 	}
 
 	serializedTx, err := utils.Serialize(blobs)
 	if err != nil {
-		return nil, fmt.Errorf("%v", err)
+		return nil, err
 	}
 
 	if int64(len(serializedTx)) > collationSizelimit {
@@ -163,13 +163,13 @@ func convertRawBlobToTx(rawBlobs []utils.RawBlob) ([]*types.Transaction, error) 
 func DeserializeBlobToTx(serialisedBlob []byte) (*[]*types.Transaction, error) {
 	deserializedBlobs, err := utils.Deserialize(serialisedBlob)
 	if err != nil {
-		return nil, fmt.Errorf("%v", err)
+		return nil, err
 	}
 
 	txs, err := convertRawBlobToTx(deserializedBlobs)
 
 	if err != nil {
-		return nil, fmt.Errorf("%v", err)
+		return nil, err
 	}
 
 	return &txs, nil

--- a/sharding/collation_test.go
+++ b/sharding/collation_test.go
@@ -172,7 +172,7 @@ func runSerializeBenchmark(b *testing.B, numTransactions int) {
 	}
 }
 
-func runSerializeBlobOnlyBenchmark(b *testing.B, numTransactions int) {
+func runSerializeNoRLPBenchmark(b *testing.B, numTransactions int) {
 	txs := makeRandomTransactions(numTransactions)
 	blobs, err := SerializeTxToRawBlob(txs)
 	if err != nil {
@@ -206,7 +206,7 @@ func runDeserializeBenchmark(b *testing.B, numTransactions int) {
 	}
 }
 
-func runDeserializeBlobOnlyBenchmark(b *testing.B, numTransactions int) {
+func runDeserializeNoRLPBenchmark(b *testing.B, numTransactions int) {
 	txs := makeRandomTransactions(numTransactions)
 	blob, err := SerializeTxToBlob(txs)
 	if err != nil {
@@ -223,16 +223,16 @@ func runDeserializeBlobOnlyBenchmark(b *testing.B, numTransactions int) {
 	}
 }
 
-func BenchmarkSerializeBlobOnly10(b *testing.B) {
-	runSerializeBlobOnlyBenchmark(b, 10)
+func BenchmarkSerializeNoRLP10(b *testing.B) {
+	runSerializeNoRLPBenchmark(b, 10)
 }
 
-func BenchmarkSerializeBlobOnly100(b *testing.B) {
-	runSerializeBlobOnlyBenchmark(b, 100)
+func BenchmarkSerializeNoRLP100(b *testing.B) {
+	runSerializeNoRLPBenchmark(b, 100)
 }
 
-func BenchmarkSerializeBlobOnly1000(b *testing.B) {
-	runSerializeBlobOnlyBenchmark(b, 1000)
+func BenchmarkSerializeNoRLP1000(b *testing.B) {
+	runSerializeNoRLPBenchmark(b, 1000)
 }
 
 func BenchmarkSerialize10(b *testing.B) {
@@ -259,16 +259,16 @@ func BenchmarkDeserialize1000(b *testing.B) {
 	runDeserializeBenchmark(b, 1000)
 }
 
-func BenchmarkDeserializeBlobOnly10(b *testing.B) {
-	runDeserializeBlobOnlyBenchmark(b, 10)
+func BenchmarkDeserializeNoRLP10(b *testing.B) {
+	runDeserializeNoRLPBenchmark(b, 10)
 }
 
-func BenchmarkDeserializeBlobOnly100(b *testing.B) {
-	runDeserializeBlobOnlyBenchmark(b, 100)
+func BenchmarkDeserializeNoRLP100(b *testing.B) {
+	runDeserializeNoRLPBenchmark(b, 100)
 }
 
-func BenchmarkDeserializeBlobOnly1000(b *testing.B) {
-	runDeserializeBlobOnlyBenchmark(b, 1000)
+func BenchmarkDeserializeNoRLP1000(b *testing.B) {
+	runDeserializeNoRLPBenchmark(b, 1000)
 }
 
 func BenchmarkSerializeRoundtrip10(b *testing.B) {

--- a/sharding/collation_test.go
+++ b/sharding/collation_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/sharding/utils"
 )
 
 // fieldAccess is to access unexported fields in structs in another package
@@ -131,34 +132,153 @@ func makeTxWithGasLimit(gl uint64) *types.Transaction {
 // BENCHMARK TESTS
 
 // Helper function to generate test that completes round trip serialization tests for a specific number of transactions.
-func runBenchTest(b *testing.B, numTransactions int) {
+func makeRandomTransactions(numTransactions int) []*types.Transaction {
 	var txs []*types.Transaction
 	for i := 0; i < numTransactions; i++ {
 		data := make([]byte, 650)
 		rand.Read(data)
 		txs = append(txs, types.NewTransaction(0 /*nonce*/, common.HexToAddress("0x0") /*to*/, nil /*amount*/, 0 /*gasLimit*/, nil /*gasPrice*/, data))
 	}
+
+	return txs
+}
+
+func runSerializeRoundtrip(b *testing.B, numTransactions int) {
+	txs := makeRandomTransactions(numTransactions)
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		results, _ := SerializeTxToBlob(txs)
-		_, _ = DeserializeBlobToTx(results)
+		blob, err := SerializeTxToBlob(txs)
+		if err != nil {
+			b.Errorf("SerializeTxToBlob failed: %v", err)
+		}
+
+		_, err = DeserializeBlobToTx(blob)
+		if err != nil {
+			b.Errorf("DeserializeBlobToTx failed: %v", err)
+		}
+	}
+}
+
+func runSerializeBenchmark(b *testing.B, numTransactions int) {
+	txs := makeRandomTransactions(numTransactions)
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		_, err := SerializeTxToBlob(txs)
+		if err != nil {
+			b.Errorf("SerializeTxToBlob failed: %v", err)
+		}
+	}
+}
+
+func runSerializeBlobOnlyBenchmark(b *testing.B, numTransactions int) {
+	txs := makeRandomTransactions(numTransactions)
+	blobs, err := SerializeTxToRawBlob(txs)
+	if err != nil {
+		b.Errorf("SerializeTxToRawBlock failed: %v", err)
 	}
 
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		_, err := utils.Serialize(blobs)
+		if err != nil {
+			b.Errorf("utils.Serialize failed: %v", err)
+		}
+	}
 }
 
-func BenchmarkSerialization10(b *testing.B) {
-	runBenchTest(b, 10)
+func runDeserializeBenchmark(b *testing.B, numTransactions int) {
+	txs := makeRandomTransactions(numTransactions)
+	blob, err := SerializeTxToBlob(txs)
+	if err != nil {
+		b.Errorf("SerializeTxToRawBlock failed: %v", err)
+	}
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		_, err := DeserializeBlobToTx(blob)
+		if err != nil {
+			b.Errorf("DeserializeBlobToTx failed: %v", err)
+		}
+	}
 }
 
-func BenchmarkSerialization100(b *testing.B) {
-	runBenchTest(b, 100)
+func runDeserializeBlobOnlyBenchmark(b *testing.B, numTransactions int) {
+	txs := makeRandomTransactions(numTransactions)
+	blob, err := SerializeTxToBlob(txs)
+	if err != nil {
+		b.Errorf("SerializeTxToBlob failed: %v", err)
+	}
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		_, err := utils.Deserialize(blob)
+		if err != nil {
+			b.Errorf("utils.Deserialize failed: %v", err)
+		}
+	}
 }
 
-func BenchmarkSerialization1000(b *testing.B) {
-	runBenchTest(b, 1000)
+func BenchmarkSerializeBlobOnly10(b *testing.B) {
+	runSerializeBlobOnlyBenchmark(b, 10)
 }
 
-func BenchmarkSerialization10000(b *testing.B) {
-	runBenchTest(b, 10000)
+func BenchmarkSerializeBlobOnly100(b *testing.B) {
+	runSerializeBlobOnlyBenchmark(b, 100)
+}
+
+func BenchmarkSerializeBlobOnly1000(b *testing.B) {
+	runSerializeBlobOnlyBenchmark(b, 1000)
+}
+
+func BenchmarkSerialize10(b *testing.B) {
+	runSerializeBenchmark(b, 10)
+}
+
+func BenchmarkSerialize100(b *testing.B) {
+	runSerializeBenchmark(b, 100)
+}
+
+func BenchmarkSerialize1000(b *testing.B) {
+	runSerializeBenchmark(b, 1000)
+}
+
+func BenchmarkDeserialize10(b *testing.B) {
+	runDeserializeBenchmark(b, 10)
+}
+
+func BenchmarkDeserialize100(b *testing.B) {
+	runDeserializeBenchmark(b, 100)
+}
+
+func BenchmarkDeserialize1000(b *testing.B) {
+	runDeserializeBenchmark(b, 1000)
+}
+
+func BenchmarkDeserializeBlobOnly10(b *testing.B) {
+	runDeserializeBlobOnlyBenchmark(b, 10)
+}
+
+func BenchmarkDeserializeBlobOnly100(b *testing.B) {
+	runDeserializeBlobOnlyBenchmark(b, 100)
+}
+
+func BenchmarkDeserializeBlobOnly1000(b *testing.B) {
+	runDeserializeBlobOnlyBenchmark(b, 1000)
+}
+
+func BenchmarkSerializeRoundtrip10(b *testing.B) {
+	runSerializeRoundtrip(b, 10)
+}
+
+func BenchmarkSerializeRoundtrip100(b *testing.B) {
+	runSerializeRoundtrip(b, 100)
+}
+
+func BenchmarkSerializeRoundtrip1000(b *testing.B) {
+	runSerializeRoundtrip(b, 1000)
 }

--- a/sharding/collation_test.go
+++ b/sharding/collation_test.go
@@ -135,7 +135,7 @@ func makeTxWithGasLimit(gl uint64) *types.Transaction {
 func makeRandomTransactions(numTransactions int) []*types.Transaction {
 	var txs []*types.Transaction
 	for i := 0; i < numTransactions; i++ {
-		data := make([]byte, 650)
+		data := make([]byte, 150)
 		rand.Read(data)
 		txs = append(txs, types.NewTransaction(0 /*nonce*/, common.HexToAddress("0x0") /*to*/, nil /*amount*/, 0 /*gasLimit*/, nil /*gasPrice*/, data))
 	}
@@ -143,6 +143,7 @@ func makeRandomTransactions(numTransactions int) []*types.Transaction {
 	return txs
 }
 
+// Benchmarks serialization and deserialization of a set of transactions
 func runSerializeRoundtrip(b *testing.B, numTransactions int) {
 	txs := makeRandomTransactions(numTransactions)
 	b.ResetTimer()
@@ -160,6 +161,7 @@ func runSerializeRoundtrip(b *testing.B, numTransactions int) {
 	}
 }
 
+// Benchmarks serialization of a set of transactions. Does both RLP encoding and serialization of blob
 func runSerializeBenchmark(b *testing.B, numTransactions int) {
 	txs := makeRandomTransactions(numTransactions)
 	b.ResetTimer()
@@ -172,9 +174,10 @@ func runSerializeBenchmark(b *testing.B, numTransactions int) {
 	}
 }
 
+// Benchmarks just the process of converting an RLP encoded set of transactions into serialized data
 func runSerializeNoRLPBenchmark(b *testing.B, numTransactions int) {
 	txs := makeRandomTransactions(numTransactions)
-	blobs, err := SerializeTxToRawBlob(txs)
+	blobs, err := convertTxToRawBlob(txs)
 	if err != nil {
 		b.Errorf("SerializeTxToRawBlock failed: %v", err)
 	}
@@ -189,6 +192,7 @@ func runSerializeNoRLPBenchmark(b *testing.B, numTransactions int) {
 	}
 }
 
+// Benchmarks deserialization of a set of transactions. Does both deserialization of blob and RLP decoding.
 func runDeserializeBenchmark(b *testing.B, numTransactions int) {
 	txs := makeRandomTransactions(numTransactions)
 	blob, err := SerializeTxToBlob(txs)
@@ -206,6 +210,7 @@ func runDeserializeBenchmark(b *testing.B, numTransactions int) {
 	}
 }
 
+// Benchmarks just the process of converting serialized data into a blob that's ready for RLP decoding
 func runDeserializeNoRLPBenchmark(b *testing.B, numTransactions int) {
 	txs := makeRandomTransactions(numTransactions)
 	blob, err := SerializeTxToBlob(txs)

--- a/sharding/collation_test.go
+++ b/sharding/collation_test.go
@@ -135,6 +135,8 @@ func makeTxWithGasLimit(gl uint64) *types.Transaction {
 func makeRandomTransactions(numTransactions int) []*types.Transaction {
 	var txs []*types.Transaction
 	for i := 0; i < numTransactions; i++ {
+		// 150 is the current average tx size, based on recent blocks (i.e. tx size = block size / # txs)
+		// for example: https://etherscan.io/block/5722271
 		data := make([]byte, 150)
 		rand.Read(data)
 		txs = append(txs, types.NewTransaction(0 /*nonce*/, common.HexToAddress("0x0") /*to*/, nil /*amount*/, 0 /*gasLimit*/, nil /*gasPrice*/, data))

--- a/sharding/utils/marshal.go
+++ b/sharding/utils/marshal.go
@@ -106,7 +106,7 @@ func Serialize(rawBlobs []*RawBlob) ([]byte, error) {
 			returnData = append(returnData, blobSlice...)
 
 			// append filler bytes, if necessary
-			if terminalLength != int(chunkDataSize ) {
+			if terminalLength != int(chunkDataSize) {
 				numFillerBytes := numChunks * int(chunkDataSize) - len(rawBlob.data)
 				fillerBytes := make([]byte, numFillerBytes)
 				returnData = append(returnData, fillerBytes...)

--- a/sharding/utils/marshal.go
+++ b/sharding/utils/marshal.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"fmt"
 	"math"
+
 	"github.com/ethereum/go-ethereum/rlp"
 )
 
@@ -47,7 +48,6 @@ func ConvertFromRawBlob(blob *RawBlob, i interface{}) error {
 	return nil
 }
 
-
 func getNumChunks(dataSize int) int {
 	numChunks := math.Ceil(float64(dataSize) / float64(chunkDataSize))
 	return int(numChunks)
@@ -87,7 +87,7 @@ func Serialize(rawBlobs []*RawBlob) ([]byte, error) {
 
 				// append indicating byte with just the length bits
 				returnData = append(returnData, byte(0))
-			 } else {
+			} else {
 				terminalLength = getTerminalLength(len(rawBlob.data))
 
 				indicatorByte := byte(terminalLength)
@@ -107,7 +107,7 @@ func Serialize(rawBlobs []*RawBlob) ([]byte, error) {
 
 			// append filler bytes, if necessary
 			if terminalLength != int(chunkDataSize) {
-				numFillerBytes := numChunks * int(chunkDataSize) - len(rawBlob.data)
+				numFillerBytes := numChunks*int(chunkDataSize) - len(rawBlob.data)
 				fillerBytes := make([]byte, numFillerBytes)
 				returnData = append(returnData, fillerBytes...)
 			}
@@ -118,7 +118,7 @@ func Serialize(rawBlobs []*RawBlob) ([]byte, error) {
 }
 
 func isSkipEvm(indicator byte) bool {
-	return indicator & skipEvmBits >> 7 == 1
+	return indicator&skipEvmBits>>7 == 1
 }
 func getDatabyteLength(indicator byte) int {
 	return int(indicator & dataLengthBits)
@@ -163,11 +163,11 @@ func Deserialize(data []byte) ([]RawBlob, error) {
 		terminalLength := serializedBlobs[i].terminalLength
 
 		blob := RawBlob{}
-		blob.data = make([]byte, 0, numNonTerminalChunks * 31 + terminalLength)
+		blob.data = make([]byte, 0, numNonTerminalChunks*31+terminalLength)
 
 		// append data from non-terminal chunks
 		for chunk := 0; chunk < numNonTerminalChunks; chunk++ {
-			dataBytes := data[currentByte+1:currentByte+32]
+			dataBytes := data[currentByte+1 : currentByte+32]
 			blob.data = append(blob.data, dataBytes...)
 			currentByte += 32
 		}
@@ -177,7 +177,7 @@ func Deserialize(data []byte) ([]RawBlob, error) {
 		}
 
 		// append data from terminal chunk
-		dataBytes := data[currentByte+1:currentByte+terminalLength+1]
+		dataBytes := data[currentByte+1 : currentByte+terminalLength+1]
 		blob.data = append(blob.data, dataBytes...)
 		currentByte += 32
 

--- a/sharding/utils/marshal.go
+++ b/sharding/utils/marshal.go
@@ -48,15 +48,18 @@ func ConvertFromRawBlob(blob *RawBlob, i interface{}) error {
 	return nil
 }
 
+// getNumChunks calculates the number of chunks that will be produced by a byte array of given length
 func getNumChunks(dataSize int) int {
 	numChunks := math.Ceil(float64(dataSize) / float64(chunkDataSize))
 	return int(numChunks)
 }
 
+// getSerializedDatasize determines the number of bytes that will be produced by a byte array of given length
 func getSerializedDatasize(dataSize int) int {
 	return getNumChunks(dataSize) * int(chunkSize)
 }
 
+// getTerminalLength determines the length of the final chunk for a byte array of given length
 func getTerminalLength(dataSize int) int {
 	numChunks := getNumChunks(dataSize)
 	return dataSize - ((numChunks - 1) * int(chunkDataSize))
@@ -117,17 +120,18 @@ func Serialize(rawBlobs []*RawBlob) ([]byte, error) {
 	return returnData, nil
 }
 
-// SKIP_EVM is true if the first bit is 1
+// isSkipEvm is true if the first bit is 1
 func isSkipEvm(indicator byte) bool {
 	return indicator&skipEvmBits >> 7 == 1
 }
 
-// Length of data is calculated by the last 5 bits
-// therefore mask the first 3 bits to 0
+// getDatabyteLength is calculated by looking at the last 5 bits.
+// Therefore, mask the first 3 bits to 0
 func getDatabyteLength(indicator byte) int {
 	return int(indicator & dataLengthBits)
 }
 
+// SerializedBlob is a helper struct used by Deserialize to determine the total size of the data byte array
 type SerializedBlob struct {
 	numNonTerminalChunks int
 	terminalLength       int

--- a/sharding/utils/marshal.go
+++ b/sharding/utils/marshal.go
@@ -117,9 +117,13 @@ func Serialize(rawBlobs []*RawBlob) ([]byte, error) {
 	return returnData, nil
 }
 
+// SKIP_EVM is true if the first bit is 1
 func isSkipEvm(indicator byte) bool {
-	return indicator&skipEvmBits>>7 == 1
+	return indicator&skipEvmBits >> 7 == 1
 }
+
+// Length of data is calculated by the last 5 bits
+// therefore mask the first 3 bits to 0
 func getDatabyteLength(indicator byte) int {
 	return int(indicator & dataLengthBits)
 }
@@ -141,11 +145,11 @@ func Deserialize(data []byte) ([]RawBlob, error) {
 		indicatorIndex := i * int(chunkSize)
 		databyteLength := getDatabyteLength(data[indicatorIndex])
 
-		// if indicator is non-terminal, increase blobSize by 31
+		// if indicator is non-terminal, increase partitions counter
 		if databyteLength == 0 {
 			numPartitions += 1
 		} else {
-			// if indicator is terminal, increase blobSize by that number and reset
+			// if indicator is terminal, append blob info and reset partitions counter
 			serializedBlob := SerializedBlob{
 				numNonTerminalChunks: numPartitions,
 				terminalLength:       databyteLength,

--- a/sharding/utils/marshal.go
+++ b/sharding/utils/marshal.go
@@ -122,7 +122,7 @@ func Serialize(rawBlobs []*RawBlob) ([]byte, error) {
 
 // isSkipEvm is true if the first bit is 1
 func isSkipEvm(indicator byte) bool {
-	return indicator&skipEvmBits >> 7 == 1
+	return indicator&skipEvmBits>>7 == 1
 }
 
 // getDatabyteLength is calculated by looking at the last 5 bits.

--- a/sharding/utils/marshal_test.go
+++ b/sharding/utils/marshal_test.go
@@ -85,7 +85,7 @@ func TestSerializeAndDeserializeblob(t *testing.T) {
 	}
 }
 
-func TestSkipEvm(t *testing.T) {
+func TestDeserializeSkipEvm(t *testing.T) {
 	data := make([]byte, 64)
 
 	// Set the indicator byte of the second chunk so that the first flag bit (SKIP_EVM) is true and the length bits equal 1
@@ -108,7 +108,7 @@ func TestSkipEvm(t *testing.T) {
 	}
 }
 
-func TestNotSkipEvm(t *testing.T) {
+func TestDeserializeSkipEvmFalse(t *testing.T) {
 	// create 64 byte array with the isSkipEVM flag turned on
 	data := make([]byte, 64)
 
@@ -132,7 +132,7 @@ func TestNotSkipEvm(t *testing.T) {
 	}
 }
 
-func TestSimpleSerialize(t *testing.T) {
+func TestSerializeSkipEvm(t *testing.T) {
 	rawBlobs := make([]*RawBlob, 1)
 	rawBlobs[0] = &RawBlob{data: make([]byte, 32)}
 	rawBlobs[0].data[31] = byte(1)
@@ -154,10 +154,9 @@ func TestSimpleSerialize(t *testing.T) {
 	if data[32] != 0x81 {
 		t.Errorf("Indicating byte for second chunk should be %v but is %v", 0x81, data[32])
 	}
-	t.Logf("data: %v", data)
 }
 
-func TestSimpleSerialize2(t *testing.T) {
+func TestSerializeSkipEvmFalse(t *testing.T) {
 	rawBlobs := make([]*RawBlob, 1)
 	rawBlobs[0] = &RawBlob{data: make([]byte, 31)}
 
@@ -171,6 +170,40 @@ func TestSimpleSerialize2(t *testing.T) {
 	}
 
 	if data[0] != 31 {
-		t.Errorf("Indicating byte for second should be %v but is %v", 31, data[0])
+		t.Errorf("Indicating byte for first chunk should be %v but is %v", 31, data[0])
+	}
+}
+
+func TestSerializeTestData(t *testing.T) {
+	rawBlobs := make([]*RawBlob, 1)
+	rawBlobs[0] = &RawBlob{data: make([]byte, 60)}
+	blobData := rawBlobs[0].data
+	for i := 0; i < len(blobData); i++ {
+		blobData[i] = byte(i)
+	}
+
+	data, err := Serialize(rawBlobs)
+	if err != nil {
+		t.Errorf("Serialize failed: %v", err)
+	}
+
+	if len(data) != 64 {
+		t.Errorf("Length of serialized data incorrect. Should be %v but is %v", 32, len(data))
+	}
+
+	if data[32] != 29 {
+		t.Errorf("Indicating byte for second chunk should be %v but is %v", 29, data[0])
+	}
+
+	for i := 1; i < 32; i++ {
+		if int(data[i]) != i-1 {
+			t.Errorf("Data byte incorrect. Should be %v but is %v", i-1, data[i])
+		}
+	}
+
+	for i := 33; i < 62; i++ {
+		if int(data[i]) != i-2 {
+			t.Errorf("Data byte incorrect. Should be %v but is %v", i-2, data[i])
+		}
 	}
 }

--- a/sharding/utils/marshal_test.go
+++ b/sharding/utils/marshal_test.go
@@ -96,15 +96,16 @@ func TestDeserializeSkipEvm(t *testing.T) {
 	}
 
 	if len(rawBlobs) != 1 {
-		t.Errorf("Length of blobs incorrect: %v", err)
+		t.Errorf("Length of blobs incorrect: %d", len(rawBlobs))
 	}
 
 	if !rawBlobs[0].flags.skipEvmExecution {
 		t.Errorf("SKIP_EVM flag is not true")
 	}
 
-	if len(rawBlobs[0].data) != 32 {
-		t.Errorf("blob size is not 32: %v", len(rawBlobs[0].data))
+	blobSize := 32
+	if len(rawBlobs[0].data) != blobSize {
+		t.Errorf("blob size should be %d but is %d", blobSize, len(rawBlobs[0].data))
 	}
 }
 
@@ -120,15 +121,16 @@ func TestDeserializeSkipEvmFalse(t *testing.T) {
 	}
 
 	if len(rawBlobs) != 1 {
-		t.Errorf("Length of blobs incorrect: %v", err)
+		t.Errorf("Length of blobs incorrect: %d", len(rawBlobs))
 	}
 
 	if rawBlobs[0].flags.skipEvmExecution {
 		t.Errorf("SKIP_EVM flag is true")
 	}
 
-	if len(rawBlobs[0].data) != 33 {
-		t.Errorf("blob size is not 33: %v", len(rawBlobs[0].data))
+	blobSize := 33
+	if len(rawBlobs[0].data) != blobSize {
+		t.Errorf("blob size should be %d but is %d", blobSize, len(rawBlobs[0].data))
 	}
 }
 
@@ -143,16 +145,18 @@ func TestSerializeSkipEvm(t *testing.T) {
 		t.Errorf("Serialize failed: %v", err)
 	}
 
-	if len(data) != 64 {
-		t.Errorf("Length of serialized data incorrect. Should be %v but is %v", 64, len(data))
+	dataSize := 64
+	if len(data) != dataSize {
+		t.Errorf("Length of serialized data incorrect. Should be %d but is %d", dataSize, len(data))
 	}
 
 	if data[0] != 0 {
-		t.Errorf("Indicating byte for first chunk should be %v but is %v", 0, data[0])
+		t.Errorf("Indicating byte for first chunk should be %x but is %x", 0, data[0])
 	}
 
-	if data[32] != 0x81 {
-		t.Errorf("Indicating byte for second chunk should be %v but is %v", 0x81, data[32])
+	indicatingByte := byte(0x81)
+	if data[32] != indicatingByte {
+		t.Errorf("Indicating byte for second chunk should be %x but is %x", indicatingByte, data[32])
 	}
 }
 
@@ -165,12 +169,14 @@ func TestSerializeSkipEvmFalse(t *testing.T) {
 		t.Errorf("Serialize failed: %v", err)
 	}
 
-	if len(data) != 32 {
-		t.Errorf("Length of serialized data incorrect. Should be %v but is %v", 32, len(data))
+	blobSize := 32
+	if len(data) != blobSize {
+		t.Errorf("Length of serialized data incorrect. Should be %d but is %d", blobSize, len(data))
 	}
 
-	if data[0] != 31 {
-		t.Errorf("Indicating byte for first chunk should be %v but is %v", 31, data[0])
+	indicatingByte := byte(0x1f)
+	if data[0] != indicatingByte {
+		t.Errorf("Indicating byte for first chunk should be %x but is %x", indicatingByte, data[0])
 	}
 }
 
@@ -187,23 +193,25 @@ func TestSerializeTestData(t *testing.T) {
 		t.Errorf("Serialize failed: %v", err)
 	}
 
-	if len(data) != 64 {
-		t.Errorf("Length of serialized data incorrect. Should be %v but is %v", 32, len(data))
+	blobSize := 64
+	if len(data) != blobSize {
+		t.Errorf("Length of serialized data incorrect. Should be %d but is %d", blobSize, len(data))
 	}
 
-	if data[32] != 29 {
-		t.Errorf("Indicating byte for second chunk should be %v but is %v", 29, data[0])
+	indicatingByte := byte(0x1D)
+	if data[32] != indicatingByte {
+		t.Errorf("Indicating byte for second chunk should be %x but is %x", indicatingByte, data[32])
 	}
 
 	for i := 1; i < 32; i++ {
-		if int(data[i]) != i-1 {
-			t.Errorf("Data byte incorrect. Should be %v but is %v", i-1, data[i])
+		if data[i] != byte(i-1) {
+			t.Errorf("Data byte incorrect. Should be %x but is %x", byte(i-1), data[i])
 		}
 	}
 
 	for i := 33; i < 62; i++ {
-		if int(data[i]) != i-2 {
-			t.Errorf("Data byte incorrect. Should be %v but is %v", i-2, data[i])
+		if data[i] != byte(i-2) {
+			t.Errorf("Data byte incorrect. Should be %x but is %x", byte(i-2), data[i])
 		}
 	}
 }


### PR DESCRIPTION
### Results

Here's the numbers on my computer for the existing benchmark with 150 byte txs
```
goos: linux
goarch: amd64
pkg: github.com/ethereum/go-ethereum/sharding
BenchmarkSerialization10-12                30000             69008 ns/op           27805 B/op        353 allocs/op
BenchmarkSerialization100-12                5000            739374 ns/op          324040 B/op       3425 allocs/op
BenchmarkSerialization1000-12                300           5558360 ns/op         3127289 B/op      34044 allocs/op
BenchmarkSerialization10000-12                30          48292393 ns/op        63835295 B/op     160091 allocs/op
PASS
```

Here's the numbers for the equivalent benchmark on this branch:

```
goos: linux
goarch: amd64
pkg: github.com/ethereum/go-ethereum/sharding
BenchmarkSerializeRoundtrip10-12          100000             37949 ns/op           15103 B/op        210 allocs/op
BenchmarkSerializeRoundtrip100-12           3000            426936 ns/op          150057 B/op       2013 allocs/op
BenchmarkSerializeRoundtrip1000-12           500           3309168 ns/op         1483492 B/op      20020 allocs/op
PASS
```

_Note: I took out benchmark tests with 10k transactions because they were hitting the [collation size limit](https://github.com/prysmaticlabs/geth-sharding/blob/master/sharding/collation.go#L150) and failing silently._

The benchmark tests are now broken up into Serialization/Deserialization, and for each of those I included a benchmark of the process without RLP.

```
goos: linux
goarch: amd64
pkg: github.com/ethereum/go-ethereum/sharding
BenchmarkSerializeNoRLP10-12             1000000              3409 ns/op            2088 B/op         11 allocs/op
BenchmarkSerializeNoRLP100-12             100000             34454 ns/op           20880 B/op        101 allocs/op
BenchmarkSerializeNoRLP1000-12              5000            330732 ns/op          200609 B/op       1001 allocs/op
BenchmarkSerialize10-12                   100000             11328 ns/op            4890 B/op         52 allocs/op
BenchmarkSerialize100-12                   10000            131254 ns/op           48999 B/op        502 allocs/op
BenchmarkSerialize1000-12                   1000           1251594 ns/op          481066 B/op       5003 allocs/op
BenchmarkDeserialize10-12                  50000             25462 ns/op           10208 B/op        158 allocs/op
BenchmarkDeserialize100-12                 10000            246955 ns/op          101008 B/op       1511 allocs/op
BenchmarkDeserialize1000-12                  500           3257192 ns/op         1001747 B/op      15014 allocs/op
BenchmarkDeserializeNoRLP10-12            500000              4435 ns/op            2736 B/op         16 allocs/op
BenchmarkDeserializeNoRLP100-12           100000             33656 ns/op           26480 B/op        109 allocs/op
BenchmarkDeserializeNoRLP1000-12            5000            333305 ns/op          257520 B/op       1012 allocs/op
BenchmarkSerializeRoundtrip10-12           50000             44685 ns/op           15103 B/op        210 allocs/op
BenchmarkSerializeRoundtrip100-12           5000            409291 ns/op          150061 B/op       2013 allocs/op
BenchmarkSerializeRoundtrip1000-12           300           5520262 ns/op         1483490 B/op      20019 allocs/op
PASS
```

RLP encoding now consumes 70-80% of wall clock time when running these benchmarks. Optimizing RLP would be the next logical step, but according to the [wiki](https://github.com/ethereum/wiki/wiki/RLP), the geth team are already aware that its inefficient and in the process of addressing perf issues.

### Optimizations
In the existing code, blob serialization/deserialization appends encoded data to an array in a loop. When data's appended to an array at full capacity, go allocates a new array with enough capacity and copies all of the data over. At 10k transactions, this becomes pretty inefficient.

```
var data []byte
for i := 0; i < len(blobs); i++ {
  // this allocates a new array on every iteration!
  data = append(data, byte(i))
}
```

Instead, I created an array with enough capacity
```
data := make([]byte, 0, len(blobs)
for i:= 0; i < len(blobs); i++ {
  data = append(data, byte(i)
}
```

I'm sure there are other optimizations that could be made, but this seemed to be the most glaring one to me. The next optimization would be to avoid encoding/decoding with both RLP and blob serialization.

Edit: Updated with `-benchmem` numbers