### PR TITLE
Implement ShardChainDB Into the ShardEthereum Instance

### DIFF
--- a/sharding/database/database.go
+++ b/sharding/database/database.go
@@ -9,17 +9,8 @@ import (
 	"github.com/ethereum/go-ethereum/ethdb"
 )
 
-// ShardBackend defines an interface for a shardDB's necessary method
-// signatures.
-type ShardBackend interface {
-	Get(k []byte) ([]byte, error)
-	Has(k []byte) (bool, error)
-	Put(k []byte, val []byte) error
-	Delete(k []byte) error
-}
-
 // NewShardDB initializes a shardDB that writes to local disk.
-func NewShardDB(dataDir string, name string) (ShardBackend, error) {
+func NewShardDB(dataDir string, name string) (ethdb.Database, error) {
 	// Uses default cache and handles values.
 	// TODO: allow these arguments to be set based on cli context.
 	return ethdb.NewLDBDatabase(filepath.Join(dataDir, name), 16, 16)

--- a/sharding/database/database_test.go
+++ b/sharding/database/database_test.go
@@ -3,9 +3,11 @@ package database
 import (
 	"strconv"
 	"testing"
+
+	"github.com/ethereum/go-ethereum/ethdb"
 )
 
-var db ShardBackend
+var db ethdb.Database
 
 func init() {
 	shardDB, err := NewShardDB("/tmp/datadir", "shardchaindata")

--- a/sharding/database/inmemory.go
+++ b/sharding/database/inmemory.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/ethdb"
 )
 
 // ShardKV is an in-memory mapping of hashes to RLP encoded values.
@@ -53,4 +54,14 @@ func (sb *ShardKV) Delete(k []byte) error {
 	// There is no return value for deleting a simple key in a go map.
 	delete(sb.kv, common.BytesToHash(k))
 	return nil
+}
+
+func (sb *ShardKV) Close() {
+	//TODO: Implement Close for ShardKV
+	panic("ShardKV Close() isnt implemented yet")
+}
+
+func (sb *ShardKV) NewBatch() ethdb.Batch {
+	//TODO: Implement NewBatch for ShardKV
+	panic("ShardKV NewBatch() isnt implemented yet")
 }

--- a/sharding/database/inmemory_test.go
+++ b/sharding/database/inmemory_test.go
@@ -2,10 +2,12 @@ package database
 
 import (
 	"testing"
+
+	"github.com/ethereum/go-ethereum/ethdb"
 )
 
-// Verifies that ShardKV implements the ShardBackend interface.
-var _ = ShardBackend(&ShardKV{})
+// Verifies that ShardKV implements the ethdb interface.
+var _ = ethdb.Database(&ShardKV{})
 
 func Test_ShardKVPut(t *testing.T) {
 	kv := NewShardKV()

--- a/sharding/node/backend.go
+++ b/sharding/node/backend.go
@@ -27,6 +27,9 @@ import (
 	cli "gopkg.in/urfave/cli.v1"
 )
 
+
+const shardChainDbName = "shardchaindata"
+
 // ShardEthereum is a service that is registered and started when geth is launched.
 // it contains APIs and fields that handle the different components of the sharded
 // Ethereum network.
@@ -190,4 +193,11 @@ func (s *ShardEthereum) registerActorService(actor string) error {
 
 		return observer.NewObserver(p2p)
 	})
+}
+
+// registerShardChainDb is relevant to all actors in the sharded system. To register
+// shardChainDb grants actor access to a persistent db (either leveldb, badger, or others)
+// the detail of which db to use is still yet to be figured out.
+func (s *ShardEthereum) registerShardChainDb(dataDir string) error {
+	return nil
 }

--- a/sharding/node/backend.go
+++ b/sharding/node/backend.go
@@ -19,12 +19,13 @@ import (
 	"github.com/ethereum/go-ethereum/sharding/mainchain"
 
 	"github.com/ethereum/go-ethereum/cmd/utils"
+	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/event"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/sharding/database"
 	"github.com/ethereum/go-ethereum/sharding/params"
 	"github.com/ethereum/go-ethereum/sharding/txpool"
-	"gopkg.in/urfave/cli.v1"
+	cli "gopkg.in/urfave/cli.v1"
 )
 
 const shardChainDbName = "shardchaindata"
@@ -33,12 +34,12 @@ const shardChainDbName = "shardchaindata"
 // it contains APIs and fields that handle the different components of the sharded
 // Ethereum network.
 type ShardEthereum struct {
-	shardConfig  *params.ShardConfig   // Holds necessary information to configure shards.
-	txPool       *txpool.ShardTXPool   // Defines the sharding-specific txpool. To be designed.
-	actor        sharding.Actor        // Either notary, proposer, or observer.
-	shardChainDb database.ShardBackend // Access to the persistent db to store shard data.
-	eventFeed    *event.Feed           // Used to enable P2P related interactions via different sharding actors.
-	smcClient    *mainchain.SMCClient  // Provides bindings to the SMC deployed on the Ethereum mainchain.
+	shardConfig  *params.ShardConfig  // Holds necessary information to configure shards.
+	txPool       *txpool.ShardTXPool  // Defines the sharding-specific txpool. To be designed.
+	actor        sharding.Actor       // Either notary, proposer, or observer.
+	shardChainDb ethdb.Database       // Access to the persistent db to store shard data.
+	eventFeed    *event.Feed          // Used to enable P2P related interactions via different sharding actors.
+	smcClient    *mainchain.SMCClient // Provides bindings to the SMC deployed on the Ethereum mainchain.
 
 	// Lifecycle and service stores.
 	services map[reflect.Type]sharding.Service // Service registry.

--- a/sharding/notary/service.go
+++ b/sharding/notary/service.go
@@ -5,6 +5,7 @@ package notary
 import (
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/sharding"
+	"github.com/ethereum/go-ethereum/sharding/database"
 	"github.com/ethereum/go-ethereum/sharding/mainchain"
 )
 
@@ -12,13 +13,14 @@ import (
 // in a sharded system. Must satisfy the Service interface defined in
 // sharding/service.go.
 type Notary struct {
-	smcClient *mainchain.SMCClient
-	shardp2p  sharding.ShardP2P
+	smcClient    *mainchain.SMCClient
+	shardp2p     sharding.ShardP2P
+	shardChainDb database.ShardBackend
 }
 
 // NewNotary creates a new notary instance.
-func NewNotary(smcClient *mainchain.SMCClient, shardp2p sharding.ShardP2P) (*Notary, error) {
-	return &Notary{smcClient, shardp2p}, nil
+func NewNotary(smcClient *mainchain.SMCClient, shardp2p sharding.ShardP2P, shardChainDb database.ShardBackend) (*Notary, error) {
+	return &Notary{smcClient, shardp2p, shardChainDb}, nil
 }
 
 // Start the main routine for a notary.

--- a/sharding/notary/service.go
+++ b/sharding/notary/service.go
@@ -3,9 +3,9 @@
 package notary
 
 import (
+	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/sharding"
-	"github.com/ethereum/go-ethereum/sharding/database"
 	"github.com/ethereum/go-ethereum/sharding/mainchain"
 )
 
@@ -15,11 +15,11 @@ import (
 type Notary struct {
 	smcClient    *mainchain.SMCClient
 	shardp2p     sharding.ShardP2P
-	shardChainDb database.ShardBackend
+	shardChainDb ethdb.Database
 }
 
 // NewNotary creates a new notary instance.
-func NewNotary(smcClient *mainchain.SMCClient, shardp2p sharding.ShardP2P, shardChainDb database.ShardBackend) (*Notary, error) {
+func NewNotary(smcClient *mainchain.SMCClient, shardp2p sharding.ShardP2P, shardChainDb ethdb.Database) (*Notary, error) {
 	return &Notary{smcClient, shardp2p, shardChainDb}, nil
 }
 

--- a/sharding/observer/service.go
+++ b/sharding/observer/service.go
@@ -5,18 +5,20 @@ package observer
 import (
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/sharding"
+	"github.com/ethereum/go-ethereum/sharding/database"
 )
 
 // Observer holds functionality required to run an observer service
 // in a sharded system. Must satisfy the Service interface defined in
 // sharding/service.go.
 type Observer struct {
-	shardp2p sharding.ShardP2P
+	shardp2p     sharding.ShardP2P
+	shardChainDb database.ShardBackend
 }
 
 // NewObserver creates a new observer instance.
-func NewObserver(shardp2p sharding.ShardP2P) (*Observer, error) {
-	return &Observer{shardp2p}, nil
+func NewObserver(shardp2p sharding.ShardP2P, shardChainDb database.ShardBackend) (*Observer, error) {
+	return &Observer{shardp2p, shardChainDb}, nil
 }
 
 // Start the main routine for an observer.

--- a/sharding/observer/service.go
+++ b/sharding/observer/service.go
@@ -3,9 +3,9 @@
 package observer
 
 import (
+	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/sharding"
-	"github.com/ethereum/go-ethereum/sharding/database"
 )
 
 // Observer holds functionality required to run an observer service
@@ -13,11 +13,11 @@ import (
 // sharding/service.go.
 type Observer struct {
 	shardp2p     sharding.ShardP2P
-	shardChainDb database.ShardBackend
+	shardChainDb ethdb.Database
 }
 
 // NewObserver creates a new observer instance.
-func NewObserver(shardp2p sharding.ShardP2P, shardChainDb database.ShardBackend) (*Observer, error) {
+func NewObserver(shardp2p sharding.ShardP2P, shardChainDb ethdb.Database) (*Observer, error) {
 	return &Observer{shardp2p, shardChainDb}, nil
 }
 

--- a/sharding/proposer/service.go
+++ b/sharding/proposer/service.go
@@ -3,9 +3,9 @@
 package proposer
 
 import (
+	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/sharding"
-	"github.com/ethereum/go-ethereum/sharding/database"
 	"github.com/ethereum/go-ethereum/sharding/mainchain"
 )
 
@@ -16,13 +16,13 @@ type Proposer struct {
 	client       mainchain.Client
 	shardp2p     sharding.ShardP2P
 	txpool       sharding.TXPool
-	shardChainDb database.ShardBackend
+	shardChainDb ethdb.Database
 }
 
 // NewProposer creates a struct instance of a proposer service.
 // It will have access to a mainchain client, a shardp2p network,
 // and a shard transaction pool.
-func NewProposer(client mainchain.Client, shardp2p sharding.ShardP2P, txpool sharding.TXPool, shardChainDb database.ShardBackend) (*Proposer, error) {
+func NewProposer(client mainchain.Client, shardp2p sharding.ShardP2P, txpool sharding.TXPool, shardChainDb ethdb.Database) (*Proposer, error) {
 	// Initializes a  directory persistent db.
 	return &Proposer{client, shardp2p, txpool, shardChainDb}, nil
 }

--- a/sharding/proposer/service.go
+++ b/sharding/proposer/service.go
@@ -5,6 +5,7 @@ package proposer
 import (
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/sharding"
+	"github.com/ethereum/go-ethereum/sharding/database"
 	"github.com/ethereum/go-ethereum/sharding/mainchain"
 )
 
@@ -12,17 +13,18 @@ import (
 // in a sharded system. Must satisfy the Service interface defined in
 // sharding/service.go.
 type Proposer struct {
-	client   mainchain.Client
-	shardp2p sharding.ShardP2P
-	txpool   sharding.TXPool
+	client       mainchain.Client
+	shardp2p     sharding.ShardP2P
+	txpool       sharding.TXPool
+	shardChainDb database.ShardBackend
 }
 
 // NewProposer creates a struct instance of a proposer service.
 // It will have access to a mainchain client, a shardp2p network,
 // and a shard transaction pool.
-func NewProposer(client mainchain.Client, shardp2p sharding.ShardP2P, txpool sharding.TXPool) (*Proposer, error) {
+func NewProposer(client mainchain.Client, shardp2p sharding.ShardP2P, txpool sharding.TXPool, shardChainDb database.ShardBackend) (*Proposer, error) {
 	// Initializes a  directory persistent db.
-	return &Proposer{client, shardp2p, txpool}, nil
+	return &Proposer{client, shardp2p, txpool, shardChainDb}, nil
 }
 
 // Start the main loop for proposing collations.

--- a/sharding/shard.go
+++ b/sharding/shard.go
@@ -6,8 +6,8 @@ import (
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/rlp"
-	"github.com/ethereum/go-ethereum/sharding/database"
 )
 
 // Shard defines a way for services attached to a sharding-enabled node to
@@ -15,12 +15,12 @@ import (
 // an abstraction that contains useful methods to fetch collations corresponding to
 // a shard from the DB, methods to check for data availability, and more.
 type Shard struct {
-	shardDB database.ShardBackend
+	shardDB ethdb.Database
 	shardID *big.Int
 }
 
 // NewShard creates an instance of a Shard struct given a shardID.
-func NewShard(shardID *big.Int, shardDB database.ShardBackend) *Shard {
+func NewShard(shardID *big.Int, shardDB ethdb.Database) *Shard {
 	return &Shard{
 		shardID: shardID,
 		shardDB: shardDB,

--- a/sharding/shard_test.go
+++ b/sharding/shard_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto/sha3"
+	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/ethereum/go-ethereum/sharding/database"
 )
@@ -30,6 +31,13 @@ func (m *mockShardDB) Put(k []byte, v []byte) error {
 
 func (m *mockShardDB) Delete(k []byte) error {
 	return fmt.Errorf("error deleting value in db")
+}
+
+func (m *mockShardDB) Close() {
+}
+
+func (m *mockShardDB) NewBatch() ethdb.Batch {
+	return nil
 }
 
 // Hash returns the hash of a collation's entire contents. Useful for comparison tests.


### PR DESCRIPTION
This PR is to address #156. With shardEthereum as a container of every single sharding service, we can integrate our DB service shardChainDB into our shardEthereum container. We'll integrate sharding/database subpackage by giving shardEthereum levelDB support or other key-value stores (leveldb, badger, or others) support. We'll also verify shardDb instance can be used across different services

work flow:
- [x] initialize shardChainDB
- [x] assign initialized `shardChainDB` to `shardEthereum.shardChainDb` instance
- [x] make sure the relevant actor services have accesses to shardChainDB service