### PR TITLE
Graceful Shutdown on SIGINT and Non-Blocking Services

### DIFF
--- a/sharding/interfaces.go
+++ b/sharding/interfaces.go
@@ -45,7 +45,7 @@ type ServiceConstructor func(ctx *ServiceContext) (Service, error)
 type Service interface {
 	// Start is called after all services have been constructed to
 	// spawn any goroutines required by the service.
-	Start() error
+	Start()
 	// Stop terminates all goroutines belonging to the service,
 	// blocking until they are all terminated.
 	Stop() error

--- a/sharding/node/backend.go
+++ b/sharding/node/backend.go
@@ -12,6 +12,7 @@ import (
 	"sync"
 	"syscall"
 
+	"github.com/ethereum/go-ethereum/internal/debug"
 	"github.com/ethereum/go-ethereum/sharding/notary"
 	"github.com/ethereum/go-ethereum/sharding/observer"
 	shardp2p "github.com/ethereum/go-ethereum/sharding/p2p"
@@ -110,12 +111,9 @@ func (s *ShardEthereum) Start() {
 
 	log.Info("Starting sharding node")
 
-	for kind, service := range s.services {
+	for _, service := range s.services {
 		// Start the next service.
-		if err := service.Start(); err != nil {
-			log.Error(fmt.Sprintf("Could not start service: %v, %v", kind, err))
-			s.Close()
-		}
+		service.Start()
 	}
 
 	go func() {
@@ -131,6 +129,9 @@ func (s *ShardEthereum) Start() {
 				log.Warn("Already shutting down, interrupt more to panic.", "times", i-1)
 			}
 		}
+		// ensure trace and CPU profile data is flushed.
+		debug.Exit()
+		debug.LoudPanic("boom")
 	}()
 
 	// hang forever...
@@ -145,7 +146,6 @@ func (s *ShardEthereum) Close() {
 		}
 	}
 	log.Info("Stopping sharding node")
-	os.Exit(1)
 }
 
 // SMCClient returns an instance of a client that communicates to a mainchain node via

--- a/sharding/observer/service.go
+++ b/sharding/observer/service.go
@@ -22,9 +22,8 @@ func NewObserver(shardp2p sharding.ShardP2P, shardChainDb ethdb.Database) (*Obse
 }
 
 // Start the main routine for an observer.
-func (o *Observer) Start() error {
+func (o *Observer) Start() {
 	log.Info("Starting shard observer service")
-	return nil
 }
 
 // Stop the main loop for observing the shard network.

--- a/sharding/p2p/service.go
+++ b/sharding/p2p/service.go
@@ -14,9 +14,8 @@ func NewServer() (*Server, error) {
 }
 
 // Start the main routine for an shardp2p server.
-func (s *Server) Start() error {
+func (s *Server) Start() {
 	log.Info("Starting shardp2p server")
-	return nil
 }
 
 // Stop the main shardp2p loop..

--- a/sharding/txpool/service.go
+++ b/sharding/txpool/service.go
@@ -17,9 +17,8 @@ func NewShardTXPool(p2p sharding.ShardP2P) (*ShardTXPool, error) {
 }
 
 // Start the main routine for a shard transaction pool.
-func (p *ShardTXPool) Start() error {
+func (p *ShardTXPool) Start() {
 	log.Info("Starting shard txpool service")
-	return nil
 }
 
 // Stop the main loop for a transaction pool in the shard network.


### PR DESCRIPTION
Hi all,

This is a PR to handle graceful shutdown of the sharding node upon signal interrupts, using similar mechanisms to Geth with respect to even including ["panic mode"](https://github.com/ethereum/go-ethereum/blob/6cf0ab38bd0af77d81aad4c104979cebee9e3e63/cmd/utils/cmd.go#L74) where a user can keep doing ctrl-c to force a shutdown.

This PR also converts the current actor services (proposers, observers, notaries) into non-blocking services via goroutines. Error handling is done within these goroutines to prevent from blocking the main sharding node thread.

## Requirements for Merge
- [x] Convert notary/proposer to non-blocking
- [x] Implement signal interrupt graceful shutdown handlers
- [x] Include Geth's panic mode of allowing for 10 signal interrupts to forcefully shut down the system