### PR TITLE
Implement shardchainDB as a service

### DIFF
--- a/sharding/database/database.go
+++ b/sharding/database/database.go
@@ -4,6 +4,7 @@
 package database
 
 import (
+	"fmt"
 	"path/filepath"
 
 	"github.com/ethereum/go-ethereum/ethdb"
@@ -11,27 +12,35 @@ import (
 )
 
 type ShardDB struct {
-	db *ethdb.LDBDatabase
+	dataDir string
+	name    string
+	cache   int
+	handles int
+	db      *ethdb.LDBDatabase
 }
 
-// NewShardDB initializes a shardDB that writes to local disk.
+// NewShardDB initializes a shardDB.
 func NewShardDB(dataDir string, name string) (*ShardDB, error) {
 	// Uses default cache and handles values.
 	// TODO: allow these arguments to be set based on cli context.
-
-	db, err := ethdb.NewLDBDatabase(filepath.Join(dataDir, name), 16, 16)
-	if err != nil {
-		return nil, err
-	}
-
 	return &ShardDB{
-		db: db,
+		dataDir: dataDir,
+		name:    name,
+		cache:   16,
+		handles: 16,
+		db:      nil,
 	}, nil
 }
 
 // Start the shard DB service.
 func (s *ShardDB) Start() {
 	log.Info("Starting shardDB service")
+	db, err := ethdb.NewLDBDatabase(filepath.Join(s.dataDir, s.name), s.cache, s.handles)
+	if err != nil {
+		log.Error(fmt.Sprintf("Could not start shard DB: %v", err))
+		return
+	}
+	s.db = db
 }
 
 // Stop the shard DB service gracefully.

--- a/sharding/database/database.go
+++ b/sharding/database/database.go
@@ -7,11 +7,36 @@ import (
 	"path/filepath"
 
 	"github.com/ethereum/go-ethereum/ethdb"
+	"github.com/ethereum/go-ethereum/log"
 )
 
+type ShardDB struct {
+	db *ethdb.LDBDatabase
+}
+
 // NewShardDB initializes a shardDB that writes to local disk.
-func NewShardDB(dataDir string, name string) (ethdb.Database, error) {
+func NewShardDB(dataDir string, name string) (*ShardDB, error) {
 	// Uses default cache and handles values.
 	// TODO: allow these arguments to be set based on cli context.
-	return ethdb.NewLDBDatabase(filepath.Join(dataDir, name), 16, 16)
+
+	db, err := ethdb.NewLDBDatabase(filepath.Join(dataDir, name), 16, 16)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ShardDB{
+		db: db,
+	}, nil
+}
+
+// Start the shard DB service.
+func (s *ShardDB) Start() {
+	log.Info("Starting shardDB service")
+}
+
+// Stop the shard DB service gracefully.
+func (s *ShardDB) Stop() error {
+	log.Info("Stopping shardDB service")
+	s.db.Close()
+	return nil
 }

--- a/sharding/internal/log_helper.go
+++ b/sharding/internal/log_helper.go
@@ -43,6 +43,6 @@ func (h *LogHandler) VerifyLogMsg(str string) {
 		h.t.Error("Expected a log, but there were none!")
 	}
 	if l := h.Pop(); l.Msg != str {
-		h.t.Errorf("Unexpected log: %v. Wanted: %s", l, str)
+		h.t.Errorf("Unexpected log: %v. Wanted: %s", l.Msg, str)
 	}
 }

--- a/sharding/node/backend.go
+++ b/sharding/node/backend.go
@@ -39,7 +39,6 @@ type ShardEthereum struct {
 	shardConfig  *params.Config // Holds necessary information to configure shards.
 	txPool       *txpool.TXPool // Defines the sharding-specific txpool. To be designed.
 	actor        sharding.Actor // Either notary, proposer, or observer.
-	shardChainDb ethdb.Database // Access to the persistent db to store shard data.
 	eventFeed    *event.Feed    // Used to enable P2P related interactions via different sharding actors.
 
 	// Lifecycle and service stores.
@@ -61,17 +60,12 @@ func New(ctx *cli.Context) (*ShardEthereum, error) {
 		path = ctx.GlobalString(utils.DataDirFlag.Name)
 	}
 
-	shardChainDb, err := database.NewShardDB(path, shardChainDbName)
-	if err != nil {
-		return nil, err
-	}
-
 	// Configure shardConfig by loading the default.
 	shardEthereum.shardConfig = params.DefaultConfig
 
-	// Adds the initialized shardChainDb to the ShardEthereum instance.
-	// TODO: Move out of here!
-	shardEthereum.shardChainDb = shardChainDb
+	if err := shardEthereum.registerShardChainDB(ctx); err != nil {
+		return nil, err
+	}
 
 	if err := shardEthereum.registerP2P(); err != nil {
 		return nil, err
@@ -175,6 +169,17 @@ func (s *ShardEthereum) Register(constructor sharding.ServiceConstructor) error 
 	return nil
 }
 
+// registerShardChainDB attaches a LevelDB wrapped object to the shardEthereum instance.
+func (s *ShardEthereum) registerShardChainDB(ctx *cli.Context) error {
+	path := node.DefaultDataDir()
+	if ctx.GlobalIsSet(utils.DataDirFlag.Name) {
+		path = ctx.GlobalString(utils.DataDirFlag.Name)
+	}
+	return s.Register(func(ctx *sharding.ServiceContext) (sharding.Service, error) {
+		return database.NewShardDB(path, shardChainDbName)
+	})
+}
+
 // registerP2P attaches a p2p server to the ShardEthereum instance.
 // TODO: Design this p2p service and the methods it should expose as well as
 // its event loop.
@@ -230,14 +235,16 @@ func (s *ShardEthereum) registerActorService(config *params.Config, actor string
 		ctx.RetrieveService(&p2p)
 		var smcClient *mainchain.SMCClient
 		ctx.RetrieveService(&smcClient)
+		var shardChainDB *database.ShardDB
+		ctx.RetrieveService(&shardChainDB)
 
 		if actor == "notary" {
-			return notary.NewNotary(config, smcClient, p2p, s.shardChainDb)
+			return notary.NewNotary(config, smcClient, p2p, shardChainDB)
 		} else if actor == "proposer" {
 			var txPool *txpool.TXPool
 			ctx.RetrieveService(&txPool)
-			return proposer.NewProposer(config, smcClient, p2p, txPool, s.shardChainDb, shardID)
+			return proposer.NewProposer(config, smcClient, p2p, txPool, shardChainDB, shardID)
 		}
-		return observer.NewObserver(p2p, s.shardChainDb, shardID)
+		return observer.NewObserver(p2p, shardChainDB, shardID)
 	})
 }

--- a/sharding/node/backend.go
+++ b/sharding/node/backend.go
@@ -13,7 +13,6 @@ import (
 	"syscall"
 
 	"github.com/ethereum/go-ethereum/cmd/utils"
-	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/event"
 	"github.com/ethereum/go-ethereum/internal/debug"
 	"github.com/ethereum/go-ethereum/log"
@@ -36,10 +35,10 @@ const shardChainDbName = "shardchaindata"
 // it contains APIs and fields that handle the different components of the sharded
 // Ethereum network.
 type ShardEthereum struct {
-	shardConfig  *params.Config // Holds necessary information to configure shards.
-	txPool       *txpool.TXPool // Defines the sharding-specific txpool. To be designed.
-	actor        sharding.Actor // Either notary, proposer, or observer.
-	eventFeed    *event.Feed    // Used to enable P2P related interactions via different sharding actors.
+	shardConfig *params.Config // Holds necessary information to configure shards.
+	txPool      *txpool.TXPool // Defines the sharding-specific txpool. To be designed.
+	actor       sharding.Actor // Either notary, proposer, or observer.
+	eventFeed   *event.Feed    // Used to enable P2P related interactions via different sharding actors.
 
 	// Lifecycle and service stores.
 	services map[reflect.Type]sharding.Service // Service registry.
@@ -53,11 +52,6 @@ func New(ctx *cli.Context) (*ShardEthereum, error) {
 	shardEthereum := &ShardEthereum{
 		services: make(map[reflect.Type]sharding.Service),
 		stop:     make(chan struct{}),
-	}
-
-	path := node.DefaultDataDir()
-	if ctx.GlobalIsSet(utils.DataDirFlag.Name) {
-		path = ctx.GlobalString(utils.DataDirFlag.Name)
 	}
 
 	// Configure shardConfig by loading the default.

--- a/sharding/notary/service.go
+++ b/sharding/notary/service.go
@@ -5,8 +5,8 @@ package notary
 import (
 	"fmt"
 
-	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/sharding/database"
 	"github.com/ethereum/go-ethereum/sharding/mainchain"
 	"github.com/ethereum/go-ethereum/sharding/p2p"
 	"github.com/ethereum/go-ethereum/sharding/params"
@@ -19,11 +19,11 @@ type Notary struct {
 	config       *params.Config
 	smcClient    *mainchain.SMCClient
 	p2p          *p2p.Server
-	shardChainDb ethdb.Database
+	shardChainDb *database.ShardDB
 }
 
 // NewNotary creates a new notary instance.
-func NewNotary(config *params.Config, smcClient *mainchain.SMCClient, p2p *p2p.Server, shardChainDb ethdb.Database) (*Notary, error) {
+func NewNotary(config *params.Config, smcClient *mainchain.SMCClient, p2p *p2p.Server, shardChainDb *database.ShardDB) (*Notary, error) {
 	return &Notary{config, smcClient, p2p, shardChainDb}, nil
 }
 

--- a/sharding/observer/service.go
+++ b/sharding/observer/service.go
@@ -5,8 +5,8 @@ package observer
 import (
 	"fmt"
 
-	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/sharding/database"
 	"github.com/ethereum/go-ethereum/sharding/p2p"
 )
 
@@ -15,12 +15,12 @@ import (
 // sharding/service.go.
 type Observer struct {
 	p2p          *p2p.Server
-	shardChainDb ethdb.Database
+	shardChainDb *database.ShardDB
 	shardID      int
 }
 
 // NewObserver creates a new observer instance.
-func NewObserver(p2p *p2p.Server, shardChainDb ethdb.Database, shardID int) (*Observer, error) {
+func NewObserver(p2p *p2p.Server, shardChainDb *database.ShardDB, shardID int) (*Observer, error) {
 	return &Observer{p2p, shardChainDb, shardID}, nil
 }
 

--- a/sharding/proposer/service.go
+++ b/sharding/proposer/service.go
@@ -10,8 +10,8 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/sharding/database"
 	"github.com/ethereum/go-ethereum/sharding/mainchain"
 	"github.com/ethereum/go-ethereum/sharding/p2p"
 	"github.com/ethereum/go-ethereum/sharding/params"
@@ -26,14 +26,14 @@ type Proposer struct {
 	client       *mainchain.SMCClient
 	p2p          *p2p.Server
 	txpool       *txpool.TXPool
-	shardChainDb ethdb.Database
+	shardChainDb *database.ShardDB
 	shardID      int
 }
 
 // NewProposer creates a struct instance of a proposer service.
 // It will have access to a mainchain client, a p2p network,
 // and a shard transaction pool.
-func NewProposer(config *params.Config, client *mainchain.SMCClient, p2p *p2p.Server, txpool *txpool.TXPool, shardChainDb ethdb.Database, shardID int) (*Proposer, error) {
+func NewProposer(config *params.Config, client *mainchain.SMCClient, p2p *p2p.Server, txpool *txpool.TXPool, shardChainDb *database.ShardDB, shardID int) (*Proposer, error) {
 	return &Proposer{config, client, p2p, txpool, shardChainDb, shardID}, nil
 }
 


### PR DESCRIPTION
This fixes #187 
As discussed yesterday,`ShardchainDB` should not be a value in `ShardEthereum`. It should just be a registered service. This was fixed by registering ethdb's leveldb as a service via `registerShardChainDB` and pass the service to the actors.

