### PR TITLE
Increase Observer Test Coverage

### DIFF
--- a/sharding/database/database.go
+++ b/sharding/database/database.go
@@ -49,3 +49,8 @@ func (s *ShardDB) Stop() error {
 	s.db.Close()
 	return nil
 }
+
+// DB returns the attached ethdb instance.
+func (s *ShardDB) DB() ethdb.Database {
+	return s.db
+}

--- a/sharding/node/backend.go
+++ b/sharding/node/backend.go
@@ -239,6 +239,6 @@ func (s *ShardEthereum) registerActorService(config *params.Config, actor string
 			ctx.RetrieveService(&txPool)
 			return proposer.NewProposer(config, smcClient, p2p, txPool, shardChainDB, shardID)
 		}
-		return observer.NewObserver(p2p, shardChainDB, shardID)
+		return observer.NewObserver(p2p, shardChainDB.DB(), shardID)
 	})
 }

--- a/sharding/observer/service.go
+++ b/sharding/observer/service.go
@@ -3,14 +3,14 @@
 package observer
 
 import (
-	"fmt"
-
 	"context"
+	"fmt"
+	"math/big"
+
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/sharding"
 	"github.com/ethereum/go-ethereum/sharding/p2p"
-	"math/big"
 )
 
 // Observer holds functionality required to run an observer service

--- a/sharding/observer/service.go
+++ b/sharding/observer/service.go
@@ -23,8 +23,8 @@ type Observer struct {
 	cancel context.CancelFunc
 }
 
-// NewObserver creates a struct instance of a observer service.
-// It will have access to a p2p server and a shardChainDb.
+// NewObserver creates a struct instance of a observer service,
+// it will have access to a p2p server and a shardChainDb.
 func NewObserver(p2p *p2p.Server, shardChainDb ethdb.Database, shardID int) (*Observer, error) {
 	ctx, cancel := context.WithCancel(context.Background())
 	shard := sharding.NewShard(big.NewInt(int64(shardID)), shardChainDb)
@@ -33,11 +33,14 @@ func NewObserver(p2p *p2p.Server, shardChainDb ethdb.Database, shardID int) (*Ob
 
 // Start the main loop for observer service.
 func (o *Observer) Start() {
-	log.Info(fmt.Sprintf("Starting observer service."))
+	log.Info(fmt.Sprintf("Starting observer service"))
 }
 
 // Stop the main loop for observer service.
 func (o *Observer) Stop() error {
-	log.Info(fmt.Sprintf("Stopping observer service."))
+	// Triggers a cancel call in the service's context which shuts down every goroutine
+	// in this service.
+	defer o.cancel()
+	log.Info(fmt.Sprintf("Stopping observer service"))
 	return nil
 }

--- a/sharding/observer/service.go
+++ b/sharding/observer/service.go
@@ -5,32 +5,39 @@ package observer
 import (
 	"fmt"
 
+	"context"
+	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/log"
-	"github.com/ethereum/go-ethereum/sharding/database"
+	"github.com/ethereum/go-ethereum/sharding"
 	"github.com/ethereum/go-ethereum/sharding/p2p"
+	"math/big"
 )
 
 // Observer holds functionality required to run an observer service
 // in a sharded system. Must satisfy the Service interface defined in
 // sharding/service.go.
 type Observer struct {
-	p2p          *p2p.Server
-	shardChainDb *database.ShardDB
-	shardID      int
+	p2p    *p2p.Server
+	shard  *sharding.Shard
+	ctx    context.Context
+	cancel context.CancelFunc
 }
 
-// NewObserver creates a new observer instance.
-func NewObserver(p2p *p2p.Server, shardChainDb *database.ShardDB, shardID int) (*Observer, error) {
-	return &Observer{p2p, shardChainDb, shardID}, nil
+// NewObserver creates a struct instance of a observer service.
+// It will have access to a p2p server and a shardChainDb.
+func NewObserver(p2p *p2p.Server, shardChainDb ethdb.Database, shardID int) (*Observer, error) {
+	ctx, cancel := context.WithCancel(context.Background())
+	shard := sharding.NewShard(big.NewInt(int64(shardID)), shardChainDb)
+	return &Observer{p2p, shard, ctx, cancel}, nil
 }
 
-// Start the main routine for an observer.
+// Start the main loop for observer service.
 func (o *Observer) Start() {
-	log.Info(fmt.Sprintf("Starting observer service in shard %d", o.shardID))
+	log.Info(fmt.Sprintf("Starting observer service."))
 }
 
-// Stop the main loop for observing the shard network.
+// Stop the main loop for observer service.
 func (o *Observer) Stop() error {
-	log.Info(fmt.Sprintf("Starting observer service in shard %d", o.shardID))
+	log.Info(fmt.Sprintf("Stopping observer service."))
 	return nil
 }

--- a/sharding/observer/service_test.go
+++ b/sharding/observer/service_test.go
@@ -1,6 +1,46 @@
 package observer
 
-import "github.com/ethereum/go-ethereum/sharding"
+import (
+	"testing"
+
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/sharding"
+	internal "github.com/ethereum/go-ethereum/sharding/internal"
+	"github.com/ethereum/go-ethereum/sharding/p2p"
+	"github.com/ethereum/go-ethereum/sharding/database"
+)
 
 // Verifies that Observer implements the Actor interface.
 var _ = sharding.Actor(&Observer{})
+
+func TestStartStop(t *testing.T) {
+	h := internal.NewLogHandler(t)
+	log.Root().SetHandler(h)
+
+	server, err := p2p.NewServer()
+	if err != nil {
+		t.Fatalf("Unable to setup p2p server: %v", err)
+	}
+	shardChainDB := database.NewShardKV()
+	shardID := 0
+
+	observer, err := NewObserver(server, shardChainDB, shardID)
+	if err != nil {
+		t.Fatalf("Unable to set up observer service: %v", err)
+	}
+
+	observer.Start()
+
+	h.VerifyLogMsg("Starting observer service")
+
+	err = observer.Stop()
+	if err != nil {
+		t.Fatalf("Unable to stop observer service: %v", err)
+	}
+
+	h.VerifyLogMsg("Stopping observer service")
+
+	if observer.ctx.Err() == nil {
+		t.Errorf("Context was not cancelled")
+	}
+}

--- a/sharding/observer/service_test.go
+++ b/sharding/observer/service_test.go
@@ -5,9 +5,9 @@ import (
 
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/sharding"
+	"github.com/ethereum/go-ethereum/sharding/database"
 	internal "github.com/ethereum/go-ethereum/sharding/internal"
 	"github.com/ethereum/go-ethereum/sharding/p2p"
-	"github.com/ethereum/go-ethereum/sharding/database"
 )
 
 // Verifies that Observer implements the Actor interface.


### PR DESCRIPTION
The goal of this PR is to increase test coverage for observer package. There's currently no test and it's at 0%

```
❰terencetsao❙ ≻ go test -cover
testing: warning: no tests to run
PASS
coverage: 0.0% of statements
ok  	github.com/ethereum/go-ethereum/sharding/observer	0.136s
```