### PR TITLE
Use Small Interfaces to Fix Nil Pointer Errors in Simulator/Syncer Tests

### DIFF
--- a/sharding/node/backend.go
+++ b/sharding/node/backend.go
@@ -263,7 +263,7 @@ func (s *ShardEthereum) registerSimulatorService(config *params.Config, shardID 
 		ctx.RetrieveService(&p2p)
 		var smcClient *mainchain.SMCClient
 		ctx.RetrieveService(&smcClient)
-		return simulator.NewSimulator(config, smcClient, p2p, shardID, 15) // 15 second delay between simulator requests.
+		return simulator.NewSimulator(config, smcClient.ChainReader(), smcClient.SMCCaller(), p2p, shardID, 15) // 15 second delay between simulator requests.
 	})
 }
 

--- a/sharding/simulator/service_test.go
+++ b/sharding/simulator/service_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/sharding"
 	internal "github.com/ethereum/go-ethereum/sharding/internal"
-	"github.com/ethereum/go-ethereum/sharding/mainchain"
 	"github.com/ethereum/go-ethereum/sharding/p2p"
 	"github.com/ethereum/go-ethereum/sharding/params"
 )
@@ -87,7 +86,7 @@ func TestStartStop(t *testing.T) {
 		t.Fatalf("Unable to setup p2p server: %v", err)
 	}
 
-	simulator, err := NewSimulator(params.DefaultConfig, &mainchain.SMCClient{}, server, shardID, 0)
+	simulator, err := NewSimulator(params.DefaultConfig, &goodReader{}, &goodSMCCaller{}, server, shardID, 0)
 	if err != nil {
 		t.Fatalf("Unable to setup simulator service: %v", err)
 	}
@@ -121,7 +120,7 @@ func TestSimulateNotaryRequests_FaultyReader(t *testing.T) {
 		t.Fatalf("Unable to setup p2p server: %v", err)
 	}
 
-	simulator, err := NewSimulator(params.DefaultConfig, &mainchain.SMCClient{}, server, shardID, 0)
+	simulator, err := NewSimulator(params.DefaultConfig, &faultyReader{}, &goodSMCCaller{}, server, shardID, 0)
 	if err != nil {
 		t.Fatalf("Unable to setup simulator service: %v", err)
 	}
@@ -160,7 +159,7 @@ func TestSimulateNotaryRequests_FaultyCaller(t *testing.T) {
 		t.Fatalf("Unable to setup p2p server: %v", err)
 	}
 
-	simulator, err := NewSimulator(params.DefaultConfig, &mainchain.SMCClient{}, server, shardID, 0)
+	simulator, err := NewSimulator(params.DefaultConfig, &goodReader{}, &faultySMCCaller{}, server, shardID, 0)
 	if err != nil {
 		t.Fatalf("Unable to setup simulator service: %v", err)
 	}
@@ -199,7 +198,7 @@ func TestSimulateNotaryRequests(t *testing.T) {
 		t.Fatalf("Unable to setup p2p server: %v", err)
 	}
 
-	simulator, err := NewSimulator(params.DefaultConfig, &mainchain.SMCClient{}, server, shardID, 0)
+	simulator, err := NewSimulator(params.DefaultConfig, &goodReader{}, &goodSMCCaller{}, server, shardID, 0)
 	if err != nil {
 		t.Fatalf("Unable to setup simulator service: %v", err)
 	}
@@ -221,7 +220,6 @@ func TestSimulateNotaryRequests(t *testing.T) {
 // TODO: Move this to the utils package along with the handleServiceErrors
 // function.
 func TestHandleServiceErrors(t *testing.T) {
-
 	h := internal.NewLogHandler(t)
 	log.Root().SetHandler(h)
 
@@ -231,7 +229,7 @@ func TestHandleServiceErrors(t *testing.T) {
 		t.Fatalf("Unable to setup p2p server: %v", err)
 	}
 
-	simulator, err := NewSimulator(params.DefaultConfig, &mainchain.SMCClient{}, server, shardID, 0)
+	simulator, err := NewSimulator(params.DefaultConfig, &goodReader{}, &goodSMCCaller{}, server, shardID, 0)
 	if err != nil {
 		t.Fatalf("Unable to setup simulator service: %v", err)
 	}

--- a/sharding/syncer/service.go
+++ b/sharding/syncer/service.go
@@ -21,7 +21,7 @@ import (
 // items such as transactions and in future sharding iterations: state.
 type Syncer struct {
 	config       *params.Config
-	client       *mainchain.SMCClient
+	signer       mainchain.Signer
 	shard        *sharding.Shard
 	p2p          *p2p.Server
 	ctx          context.Context
@@ -31,20 +31,20 @@ type Syncer struct {
 }
 
 // NewSyncer creates a struct instance of a syncer service.
-// It will have access to config, a mainchain client, a p2p server,
+// It will have access to config, a signer, a p2p server,
 // a shardChainDb, and a shardID.
-func NewSyncer(config *params.Config, client *mainchain.SMCClient, p2p *p2p.Server, shardChainDB ethdb.Database, shardID int) (*Syncer, error) {
+func NewSyncer(config *params.Config, signer mainchain.Signer, p2p *p2p.Server, shardChainDB ethdb.Database, shardID int) (*Syncer, error) {
 	ctx, cancel := context.WithCancel(context.Background())
 	shard := sharding.NewShard(big.NewInt(int64(shardID)), shardChainDB)
 	errChan := make(chan error)
 	responseSent := make(chan int)
-	return &Syncer{config, client, shard, p2p, ctx, cancel, errChan, responseSent}, nil
+	return &Syncer{config, signer, shard, p2p, ctx, cancel, errChan, responseSent}, nil
 }
 
 // Start the main loop for handling shard chain data requests.
 func (s *Syncer) Start() {
 	log.Info("Starting sync service")
-	go s.handleCollationBodyRequests(s.client, s.p2p.Feed(messages.CollationBodyRequest{}))
+	go s.handleCollationBodyRequests(s.signer, s.p2p.Feed(messages.CollationBodyRequest{}))
 	go s.handleServiceErrors()
 }
 

--- a/sharding/syncer/service_test.go
+++ b/sharding/syncer/service_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/sharding/mainchain"
 
 	"github.com/ethereum/go-ethereum/sharding/p2p/messages"
 
@@ -36,7 +35,7 @@ func TestStartStop(t *testing.T) {
 		t.Fatalf("Unable to setup p2p server: %v", err)
 	}
 
-	syncer, err := NewSyncer(params.DefaultConfig, &mainchain.SMCClient{}, server, shardChainDB, shardID)
+	syncer, err := NewSyncer(params.DefaultConfig, &mockSigner{}, server, shardChainDB, shardID)
 	if err != nil {
 		t.Fatalf("Unable to setup sync service: %v", err)
 	}
@@ -71,7 +70,7 @@ func TestHandleCollationBodyRequests_FaultySigner(t *testing.T) {
 		t.Fatalf("Unable to setup p2p server: %v", err)
 	}
 
-	syncer, err := NewSyncer(params.DefaultConfig, &mainchain.SMCClient{}, server, shardChainDB, shardID)
+	syncer, err := NewSyncer(params.DefaultConfig, &mockSigner{}, server, shardChainDB, shardID)
 	if err != nil {
 		t.Fatalf("Unable to setup syncer service: %v", err)
 	}
@@ -145,7 +144,7 @@ func TestHandleCollationBodyRequests(t *testing.T) {
 		t.Fatalf("Could not store collation in shardChainDB: %v", err)
 	}
 
-	syncer, err := NewSyncer(params.DefaultConfig, &mainchain.SMCClient{}, server, shardChainDB, 0)
+	syncer, err := NewSyncer(params.DefaultConfig, &mockSigner{}, server, shardChainDB, 0)
 	if err != nil {
 		t.Fatalf("Unable to setup syncer service: %v", err)
 	}
@@ -198,7 +197,7 @@ func TestHandleServiceErrors(t *testing.T) {
 		t.Fatalf("Unable to setup p2p server: %v", err)
 	}
 
-	syncer, err := NewSyncer(params.DefaultConfig, &mainchain.SMCClient{}, server, shardChainDB, shardID)
+	syncer, err := NewSyncer(params.DefaultConfig, &mockSigner{}, server, shardChainDB, shardID)
 	if err != nil {
 		t.Fatalf("Unable to setup syncer service: %v", err)
 	}


### PR DESCRIPTION
### What Was Wrong?

Previously, the `Simulator` struct in the simulator service would take in a `client *mainchain.SMCClient` as an input argument, making testing extremely difficult as this encompasses an rpcClient among other complex structures. This would lead us to some nil pointer errors when running tests as we would provide an incomplete `mainchain.SMCClient` to the struct initializer.

### How It Was Fixed?

This was fixed by using the pattern of smaller interfaces in our service initializers in the `simulator` and `syncer` packages. Now, `NewSimulator` looks like this:

```go
func NewSimulator(config *params.Config, reader mainchain.Reader, fetcher mainchain.RecordFetcher, p2p *p2p.Server, shardID int, delay time.Duration) (*Simulator, error)
```

Making it easy to test with simple mocks.