### PR TITLE
Use Internal Mock Client for Notary Tests

### DIFF
--- a/sharding/internal/client_helper.go
+++ b/sharding/internal/client_helper.go
@@ -96,6 +96,14 @@ func (m *MockClient) FastForward(p int) {
 	}
 }
 
+func (m *MockClient) SubscribeNewHead(ctx context.Context, ch chan<- *types.Header) (ethereum.Subscription, error) {
+	return nil, nil
+}
+
+func (m *MockClient) BlockByNumber(ctx context.Context, number *big.Int) (*types.Block, error) {
+	return types.NewBlockWithHeader(&types.Header{Number: big.NewInt(m.BlockNumber)}), nil
+}
+
 func TransactOpts() *bind.TransactOpts {
 	return bind.NewKeyedTransactor(key)
 }

--- a/sharding/notary/service_test.go
+++ b/sharding/notary/service_test.go
@@ -4,144 +4,25 @@ import (
 	"context"
 	"math/big"
 	"testing"
-	"time"
 
-	ethereum "github.com/ethereum/go-ethereum"
-	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
-	"github.com/ethereum/go-ethereum/accounts/abi/bind/backends"
-	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core"
-	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/sharding"
-	"github.com/ethereum/go-ethereum/sharding/contracts"
+	"github.com/ethereum/go-ethereum/sharding/internal"
 	shardparams "github.com/ethereum/go-ethereum/sharding/params"
 )
 
 var (
-	key, _                   = crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
-	addr                     = crypto.PubkeyToAddress(key.PublicKey)
-	accountBalance1001Eth, _ = new(big.Int).SetString("1001000000000000000000", 10)
+	key, _ = crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
+	addr   = crypto.PubkeyToAddress(key.PublicKey)
 )
 
 // Verifies that Notary implements the Actor interface.
 var _ = sharding.Actor(&Notary{})
 
-// Mock client for testing notary. Should this go into sharding/client/testing?
-type smcClient struct {
-	smc         *contracts.SMC
-	depositFlag bool
-	t           *testing.T
-	backend     *backends.SimulatedBackend
-	blocknumber int64
-}
-
-func (s *smcClient) SubscribeNewHead(ctx context.Context, ch chan<- *types.Header) (ethereum.Subscription, error) {
-	return nil, nil
-}
-
-func (s *smcClient) Account() *accounts.Account {
-	return &accounts.Account{Address: addr}
-}
-
-func (s *smcClient) SMCCaller() *contracts.SMCCaller {
-	return &s.smc.SMCCaller
-}
-
-func (s *smcClient) ChainReader() ethereum.ChainReader {
-	return nil
-}
-
-func (s *smcClient) SMCTransactor() *contracts.SMCTransactor {
-	return &s.smc.SMCTransactor
-}
-
-func (s *smcClient) SMCFilterer() *contracts.SMCFilterer {
-	return &s.smc.SMCFilterer
-}
-
-func (s *smcClient) WaitForTransaction(ctx context.Context, hash common.Hash, durationInSeconds time.Duration) error {
-	s.CommitWithBlock()
-	s.fastForward(1)
-	return nil
-}
-
-func (s *smcClient) TransactionReceipt(hash common.Hash) (*types.Receipt, error) {
-	return s.backend.TransactionReceipt(context.Background(), hash)
-}
-
-func (s *smcClient) CreateTXOpts(value *big.Int) (*bind.TransactOpts, error) {
-	txOpts := transactOpts()
-	txOpts.Value = value
-	return txOpts, nil
-}
-
-func (s *smcClient) DepositFlag() bool {
-	return s.depositFlag
-}
-
-func (s *smcClient) SetDepositFlag(deposit bool) {
-	s.depositFlag = deposit
-}
-
-func (s *smcClient) Sign(hash common.Hash) ([]byte, error) {
-	return nil, nil
-}
-
-// Unused mockClient methods.
-func (s *smcClient) Start() error {
-	s.t.Fatal("Start called")
-	return nil
-}
-
-func (s *smcClient) Close() {
-	s.t.Fatal("Close called")
-}
-
-func (s *smcClient) DataDirPath() string {
-	return "/tmp/datadir"
-}
-
-func (s *smcClient) CommitWithBlock() {
-	s.backend.Commit()
-	s.blocknumber = s.blocknumber + 1
-
-}
-
-func (s *smcClient) GetShardCount() (int64, error) {
-	return 100, nil
-}
-
-func (s *smcClient) BlockByNumber(ctx context.Context, number *big.Int) (*types.Block, error) {
-	return types.NewBlockWithHeader(&types.Header{Number: big.NewInt(s.blocknumber)}), nil
-}
-
-// Helper/setup methods.
-// TODO: consider moving these to common sharding testing package as the notary and smc tests
-// use them.
-func transactOpts() *bind.TransactOpts {
-	return bind.NewKeyedTransactor(key)
-}
-
-// fastForward is a helper function to skip through n period.
-func (s *smcClient) fastForward(p int) {
-
-	for i := 0; i < p*int(shardparams.DefaultConfig.PeriodLength); i++ {
-		s.CommitWithBlock()
-	}
-}
-
-func setup() (*backends.SimulatedBackend, *contracts.SMC) {
-	backend := backends.NewSimulatedBackend(core.GenesisAlloc{addr: {Balance: accountBalance1001Eth}})
-	_, _, smc, _ := contracts.DeploySMC(transactOpts(), backend)
-	backend.Commit()
-	return backend, smc
-}
-
 func TestHasAccountBeenDeregistered(t *testing.T) {
-	backend, smc := setup()
-	client := &smcClient{smc: smc, t: t, backend: backend, blocknumber: 1}
+	backend, smc := internal.SetupMockClient(t)
+	client := &internal.MockClient{SMC: smc, T: t, Backend: backend, BlockNumber: 1}
 
 	client.SetDepositFlag(true)
 	err := joinNotaryPool(client, client, nil)
@@ -164,12 +45,11 @@ func TestHasAccountBeenDeregistered(t *testing.T) {
 	if !dreg {
 		t.Error("account unable to be deregistered from notary pool")
 	}
-
 }
 
 func TestIsLockupOver(t *testing.T) {
-	backend, smc := setup()
-	client := &smcClient{smc: smc, t: t, backend: backend}
+	backend, smc := internal.SetupMockClient(t)
+	client := &internal.MockClient{SMC: smc, T: t, Backend: backend}
 
 	client.SetDepositFlag(true)
 	err := joinNotaryPool(client, client, shardparams.DefaultConfig)
@@ -183,7 +63,7 @@ func TestIsLockupOver(t *testing.T) {
 		t.Error(err)
 	}
 
-	client.fastForward(int(shardparams.DefaultConfig.NotaryLockupLength + 100))
+	client.FastForward(int(shardparams.DefaultConfig.NotaryLockupLength + 100))
 
 	err = releaseNotary(client, client, client)
 	if err != nil {
@@ -199,12 +79,11 @@ func TestIsLockupOver(t *testing.T) {
 	if !lockup {
 		t.Error("lockup period is not over despite account being relased from registry")
 	}
-
 }
 
 func TestIsAccountInNotaryPool(t *testing.T) {
-	backend, smc := setup()
-	client := &smcClient{smc: smc, t: t, backend: backend}
+	backend, smc := internal.SetupMockClient(t)
+	client := &internal.MockClient{SMC: smc, T: t, Backend: backend}
 
 	// address should not be in pool initially.
 	b, err := isAccountInNotaryPool(client, client.Account())
@@ -215,9 +94,7 @@ func TestIsAccountInNotaryPool(t *testing.T) {
 		t.Fatal("account unexpectedly in notary pool")
 	}
 
-	txOpts := transactOpts()
-	// deposit in notary pool, then it should return true.
-	txOpts.Value = shardparams.DefaultConfig.NotaryDeposit
+	txOpts, _ := client.CreateTXOpts(shardparams.DefaultConfig.NotaryDeposit)
 	if _, err := smc.RegisterNotary(txOpts); err != nil {
 		t.Fatalf("Failed to deposit: %v", err)
 	}
@@ -232,8 +109,9 @@ func TestIsAccountInNotaryPool(t *testing.T) {
 }
 
 func TestJoinNotaryPool(t *testing.T) {
-	backend, smc := setup()
-	client := &smcClient{smc: smc, depositFlag: false, t: t, backend: backend}
+	backend, smc := internal.SetupMockClient(t)
+	client := &internal.MockClient{SMC: smc, T: t, Backend: backend}
+
 	// There should be no notary initially.
 	numNotaries, err := smc.NotaryPoolLength(&bind.CallOpts{})
 	if err != nil {
@@ -264,7 +142,7 @@ func TestJoinNotaryPool(t *testing.T) {
 		t.Errorf("unexpected number of notaries. Got %d, wanted 1", numNotaries)
 	}
 
-	// Trying to join while deposited should do nothing
+	// Join while deposited should do nothing.
 	err = joinNotaryPool(client, client, shardparams.DefaultConfig)
 	if err != nil {
 		t.Error(err)
@@ -277,22 +155,20 @@ func TestJoinNotaryPool(t *testing.T) {
 	if big.NewInt(1).Cmp(numNotaries) != 0 {
 		t.Errorf("unexpected number of notaries. Got %d, wanted 1", numNotaries)
 	}
-
 }
 
 func TestLeaveNotaryPool(t *testing.T) {
-	backend, smc := setup()
-	client := &smcClient{smc: smc, t: t, depositFlag: true, backend: backend}
+	backend, smc := internal.SetupMockClient(t)
+	client := &internal.MockClient{SMC: smc, T: t, Backend: backend}
+	client.SetDepositFlag(true)
 
-	// Test Leaving Notary Pool Before Joining it
-
+	// Test leaving notary pool before joining it.
 	err := leaveNotaryPool(client, client)
 	if err == nil {
 		t.Error("able to leave notary pool despite having not joined it")
 	}
 
-	// Roundtrip Test , Join and leave pool
-
+	// Roundtrip test, join and leave pool.
 	err = joinNotaryPool(client, client, shardparams.DefaultConfig)
 	if err != nil {
 		t.Error(err)
@@ -321,22 +197,20 @@ func TestLeaveNotaryPool(t *testing.T) {
 	if big.NewInt(0).Cmp(numNotaries) != 0 {
 		t.Errorf("unexpected number of notaries. Got %d, wanted 0", numNotaries)
 	}
-
 }
 
 func TestReleaseNotary(t *testing.T) {
-	backend, smc := setup()
-	client := &smcClient{smc: smc, t: t, depositFlag: true, backend: backend}
+	backend, smc := internal.SetupMockClient(t)
+	client := &internal.MockClient{SMC: smc, T: t, Backend: backend}
+	client.SetDepositFlag(true)
 
-	// Test Release Notary Before Joining it
-
+	// Test release notary before joining it.
 	err := releaseNotary(client, client, client)
 	if err == nil {
 		t.Error("released From notary despite never joining pool")
 	}
 
-	// Roundtrip Test , Join and leave pool and release Notary
-
+	// Roundtrip test, join and leave pool.
 	err = joinNotaryPool(client, client, shardparams.DefaultConfig)
 	if err != nil {
 		t.Error(err)
@@ -351,7 +225,7 @@ func TestReleaseNotary(t *testing.T) {
 	if err != nil {
 		t.Error("unable to retrieve balance")
 	}
-	client.fastForward(int(shardparams.DefaultConfig.NotaryLockupLength + 10))
+	client.FastForward(int(shardparams.DefaultConfig.NotaryLockupLength + 10))
 
 	err = releaseNotary(client, client, client)
 	if err != nil {
@@ -366,7 +240,7 @@ func TestReleaseNotary(t *testing.T) {
 		t.Error("Unable to release Notary and deposit money back")
 	}
 
-	newbalance, err := client.backend.BalanceAt(context.Background(), addr, nil)
+	newbalance, err := client.Backend.BalanceAt(context.Background(), addr, nil)
 	if err != nil {
 		t.Error("unable to retrieve balance")
 	}
@@ -374,16 +248,15 @@ func TestReleaseNotary(t *testing.T) {
 	if balance.Cmp(newbalance) != -1 {
 		t.Errorf("Deposit was not returned, balance is currently: %v", newbalance)
 	}
-
 }
 
 func TestSubmitVote(t *testing.T) {
-	backend, smc := setup()
-	client := &smcClient{smc: smc, t: t, depositFlag: true, backend: backend}
+	backend, smc := internal.SetupMockClient(t)
+	client := &internal.MockClient{SMC: smc, T: t, Backend: backend}
+	client.SetDepositFlag(true)
 
 	err := joinNotaryPool(client, client, shardparams.DefaultConfig)
 	if err != nil {
 		t.Error(err)
 	}
-
 }


### PR DESCRIPTION
Continue working on #202. This PR refactors notary tests to use internal mock client.