### PR TITLE
Simplify Goroutines for Better Testing

### DIFF
--- a/sharding/database/database_test.go
+++ b/sharding/database/database_test.go
@@ -15,7 +15,7 @@ var _ = sharding.Service(&ShardDB{})
 var testDB *ShardDB
 
 func init() {
-	shardDB, _ := NewShardDB("/tmp/datadir", "shardchaindata")
+	shardDB, _ := NewShardDB("/tmp/datadir", "shardchaindata", false)
 	testDB = shardDB
 	testDB.Start()
 }
@@ -24,7 +24,7 @@ func TestLifecycle(t *testing.T) {
 	h := internal.NewLogHandler(t)
 	log.Root().SetHandler(h)
 
-	s, err := NewShardDB("/tmp/datadir", "shardchaindb")
+	s, err := NewShardDB("/tmp/datadir", "shardchaindb", false)
 	if err != nil {
 		t.Fatalf("Could not initialize a new sb: %v", err)
 	}

--- a/sharding/database/inmemory.go
+++ b/sharding/database/inmemory.go
@@ -14,7 +14,7 @@ type ShardKV struct {
 	lock sync.RWMutex
 }
 
-// NewShardKV initializes a keyval store in memory.
+// NewShardKV creates an in-memory, key-value store.
 func NewShardKV() *ShardKV {
 	return &ShardKV{kv: make(map[common.Hash][]byte)}
 }

--- a/sharding/node/backend.go
+++ b/sharding/node/backend.go
@@ -184,7 +184,7 @@ func (s *ShardEthereum) registerShardChainDB(ctx *cli.Context) error {
 		path = ctx.GlobalString(utils.DataDirFlag.Name)
 	}
 	return s.Register(func(ctx *sharding.ServiceContext) (sharding.Service, error) {
-		return database.NewShardDB(path, shardChainDbName)
+		return database.NewShardDB(path, shardChainDbName, false)
 	})
 }
 
@@ -263,7 +263,7 @@ func (s *ShardEthereum) registerSimulatorService(config *params.Config, shardID 
 		ctx.RetrieveService(&p2p)
 		var smcClient *mainchain.SMCClient
 		ctx.RetrieveService(&smcClient)
-		return simulator.NewSimulator(config, smcClient.ChainReader(), smcClient.SMCCaller(), p2p, shardID, 15) // 15 second delay between simulator requests.
+		return simulator.NewSimulator(config, smcClient, p2p, shardID, 15) // 15 second delay between simulator requests.
 	})
 }
 
@@ -275,6 +275,6 @@ func (s *ShardEthereum) registerSyncerService(config *params.Config, shardID int
 		ctx.RetrieveService(&smcClient)
 		var shardChainDB *database.ShardDB
 		ctx.RetrieveService(&shardChainDB)
-		return syncer.NewSyncer(config, smcClient, p2p, shardChainDB.DB(), shardID)
+		return syncer.NewSyncer(config, smcClient, p2p, shardChainDB, shardID)
 	})
 }

--- a/sharding/p2p/service.go
+++ b/sharding/p2p/service.go
@@ -8,6 +8,10 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 )
 
+type Sender interface {
+	Send(msg interface{}, peer Peer)
+}
+
 // Server is a placeholder for a p2p service. To be designed.
 type Server struct {
 	feeds map[reflect.Type]*event.Feed

--- a/sharding/p2p/service.go
+++ b/sharding/p2p/service.go
@@ -8,6 +8,8 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 )
 
+// Sender represents a struct that is able to relay information via shardp2p.
+// Server implements this interface.
 type Sender interface {
 	Send(msg interface{}, peer Peer)
 }

--- a/sharding/simulator/service.go
+++ b/sharding/simulator/service.go
@@ -36,7 +36,7 @@ type Simulator struct {
 // NewSimulator creates a struct instance of a simulator service.
 // It will have access to config, a mainchain client, a p2p server,
 // and a shardID.
-func NewSimulator(config *params.Config, reader mainchain.Reader, fetcher mainchain.RecordFetcher, p2p *p2p.Server, shardID int, delay time.Duration) (*Simulator, error) {
+func NewSimulator(config *params.Config, client *mainchain.SMCClient, p2p *p2p.Server, shardID int, delay time.Duration) (*Simulator, error) {
 	ctx, cancel := context.WithCancel(context.Background())
 	errChan := make(chan error)
 	return &Simulator{config, client, p2p, shardID, ctx, cancel, errChan, delay}, nil

--- a/sharding/simulator/service.go
+++ b/sharding/simulator/service.go
@@ -57,6 +57,7 @@ func (s *Simulator) Stop() error {
 	// Triggers a cancel call in the service's context which shuts down every goroutine
 	// in this service.
 	defer s.cancel()
+	defer close(s.errChan)
 	log.Warn("Stopping simulator service")
 	return nil
 }

--- a/sharding/simulator/service.go
+++ b/sharding/simulator/service.go
@@ -48,7 +48,7 @@ func (s *Simulator) Start() {
 	log.Info("Starting simulator service")
 	s.requestFeed = s.p2p.Feed(messages.CollationBodyRequest{})
 	go utils.HandleServiceErrors(s.ctx.Done(), s.errChan)
-	go s.simulateNotaryRequests(s.client.SMCCaller(), s.client.ChainReader(), time.After(time.Second*s.delay))
+	go s.simulateNotaryRequests(s.client.SMCCaller(), s.client.ChainReader(), time.Tick(time.Second*s.delay))
 }
 
 // Stop the main loop for simulator requests.

--- a/sharding/simulator/service_test.go
+++ b/sharding/simulator/service_test.go
@@ -117,15 +117,6 @@ func TestSimulateNotaryRequests_FaultyReader(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unable to setup p2p server: %v", err)
 	}
-<<<<<<< HEAD
-=======
-
-	simulator, err := NewSimulator(params.DefaultConfig, &faultyReader{}, &goodSMCCaller{}, server, shardID, 0)
-	if err != nil {
-		t.Fatalf("Unable to setup simulator service: %v", err)
-	}
-
->>>>>>> master
 	feed := server.Feed(messages.CollationBodyRequest{})
 
 	faultyReader := &faultyReader{}

--- a/sharding/syncer/service.go
+++ b/sharding/syncer/service.go
@@ -2,6 +2,7 @@ package syncer
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math/big"
 
@@ -13,6 +14,7 @@ import (
 	"github.com/ethereum/go-ethereum/sharding/p2p"
 	"github.com/ethereum/go-ethereum/sharding/p2p/messages"
 	"github.com/ethereum/go-ethereum/sharding/params"
+	"github.com/ethereum/go-ethereum/sharding/utils"
 )
 
 // Syncer represents a service that provides handlers for shard chain
@@ -26,8 +28,9 @@ type Syncer struct {
 	p2p          *p2p.Server
 	ctx          context.Context
 	cancel       context.CancelFunc
+	msgChan      chan p2p.Message
+	bodyRequests event.Subscription
 	errChan      chan error // Useful channel for handling errors at the service layer.
-	responseSent chan int   // Useful channel for handling outgoing responses from the service.
 }
 
 // NewSyncer creates a struct instance of a syncer service.
@@ -37,15 +40,18 @@ func NewSyncer(config *params.Config, client *mainchain.SMCClient, p2p *p2p.Serv
 	ctx, cancel := context.WithCancel(context.Background())
 	shard := sharding.NewShard(big.NewInt(int64(shardID)), shardChainDB)
 	errChan := make(chan error)
-	responseSent := make(chan int)
-	return &Syncer{config, client, shard, p2p, ctx, cancel, errChan, responseSent}, nil
+	return &Syncer{config, client, shard, p2p, ctx, cancel, nil, nil, errChan}, nil
 }
 
 // Start the main loop for handling shard chain data requests.
 func (s *Syncer) Start() {
 	log.Info("Starting sync service")
-	go s.handleCollationBodyRequests(s.client, s.p2p.Feed(messages.CollationBodyRequest{}))
-	go s.handleServiceErrors()
+	s.msgChan = make(chan p2p.Message, 100)
+
+	bodyRequestsFeed := s.p2p.Feed(messages.CollationBodyRequest{})
+	s.bodyRequests = bodyRequestsFeed.Subscribe(s.msgChan)
+	go handleCollationBodyRequests(s.client, s.shard, s.p2p, s.msgChan, s.ctx.Done(), s.bodyRequests, s.errChan)
+	go utils.HandleServiceErrors(s.ctx.Done(), s.errChan)
 }
 
 // Stop the main loop.
@@ -53,53 +59,38 @@ func (s *Syncer) Stop() error {
 	// Triggers a cancel call in the service's context which shuts down every goroutine
 	// in this service.
 	defer s.cancel()
+	defer close(s.errChan)
+	defer close(s.msgChan)
 	log.Warn("Stopping sync service")
+	s.bodyRequests.Unsubscribe()
 	return nil
-}
-
-// handleServiceErrors manages a goroutine that listens for errors broadcast to
-// this service's error channel. This serves as a final step for error logging
-// and is stopped upon the service shutting down.
-func (s *Syncer) handleServiceErrors() {
-	for {
-		select {
-		case <-s.ctx.Done():
-			return
-		case err := <-s.errChan:
-			log.Error(fmt.Sprintf("Sync service error: %v", err))
-		}
-	}
 }
 
 // handleCollationBodyRequests subscribes to messages from the shardp2p
 // network and responds to a specific peer that requested the body using
 // the Send method exposed by the p2p server's API (implementing the p2p.Sender interface).
-func (s *Syncer) handleCollationBodyRequests(signer mainchain.Signer, feed *event.Feed) {
-
-	ch := make(chan p2p.Message, 100)
-	sub := feed.Subscribe(ch)
-
-	defer sub.Unsubscribe()
-
+func handleCollationBodyRequests(signer mainchain.Signer, collationFetcher sharding.CollationFetcher, sender p2p.Sender, msgChan <-chan p2p.Message, done <-chan struct{}, sub event.Subscription, errChan chan<- error) {
 	for {
 		select {
 		// Makes sure to close this goroutine when the service stops.
-		case <-s.ctx.Done():
+		case <-done:
 			return
-		case req := <-ch:
+		case req := <-msgChan:
 			if req.Data != nil {
 				log.Info(fmt.Sprintf("Received p2p request of type: %T", req))
-				res, err := RespondCollationBody(req, signer, s.shard)
+				res, err := RespondCollationBody(req, signer, collationFetcher)
 				if err != nil {
-					s.errChan <- fmt.Errorf("could not construct response: %v", err)
+					errChan <- fmt.Errorf("could not construct response: %v", err)
 					continue
 				}
 
 				// Reply to that specific peer only.
-				s.p2p.Send(*res, req.Peer)
+				sender.Send(*res, req.Peer)
 				log.Info(fmt.Sprintf("Responding to p2p request with collation with headerHash: %v", res.HeaderHash.Hex()))
-				s.responseSent <- 1
 			}
+		case <-sub.Err():
+			errChan <- errors.New("subscriber failed")
+			return
 		}
 	}
 }

--- a/sharding/syncer/service_test.go
+++ b/sharding/syncer/service_test.go
@@ -115,6 +115,7 @@ func TestHandleCollationBodyRequests(t *testing.T) {
 	}
 	msgChan <- msg
 	done <- struct{}{}
+	// TODO: get this to work without timeout.
 	time.Sleep(time.Second * 5)
 	h.VerifyLogMsg(fmt.Sprintf("Received p2p request of type: %T", p2p.Message{}))
 	h.VerifyLogMsg(fmt.Sprintf("Responding to p2p request with collation with headerHash: %v", header.Hash().Hex()))

--- a/sharding/syncer/service_test.go
+++ b/sharding/syncer/service_test.go
@@ -28,7 +28,10 @@ func TestStop(t *testing.T) {
 	h := internal.NewLogHandler(t)
 	log.Root().SetHandler(h)
 
-	shardChainDB := database.NewShardKV()
+	shardChainDB, err := database.NewShardDB("", "", true)
+	if err != nil {
+		t.Fatalf("unable to setup db: %v", err)
+	}
 	shardID := 0
 	server, err := p2p.NewServer()
 	if err != nil {
@@ -64,7 +67,10 @@ func TestHandleCollationBodyRequests_FaultySigner(t *testing.T) {
 	h := internal.NewLogHandler(t)
 	log.Root().SetHandler(h)
 
-	shardChainDB := database.NewShardKV()
+	shardChainDB, err := database.NewShardDB("", "", true)
+	if err != nil {
+		t.Fatalf("unable to setup db: %v", err)
+	}
 	shardID := 0
 	server, err := p2p.NewServer()
 	if err != nil {
@@ -77,7 +83,7 @@ func TestHandleCollationBodyRequests_FaultySigner(t *testing.T) {
 	}
 
 	feed := server.Feed(messages.CollationBodyRequest{})
-	shard := sharding.NewShard(big.NewInt(int64(shardID)), shardChainDB)
+	shard := sharding.NewShard(big.NewInt(int64(shardID)), shardChainDB.DB())
 
 	syncer.msgChan = make(chan p2p.Message)
 	syncer.errChan = make(chan error)
@@ -111,7 +117,10 @@ func TestHandleCollationBodyRequests(t *testing.T) {
 	h := internal.NewLogHandler(t)
 	log.Root().SetHandler(h)
 
-	shardChainDB := database.NewShardKV()
+	shardChainDB, err := database.NewShardDB("", "", true)
+	if err != nil {
+		t.Fatalf("unable to setup db: %v", err)
+	}
 	server, err := p2p.NewServer()
 	if err != nil {
 		t.Fatalf("Unable to setup p2p server: %v", err)
@@ -136,7 +145,7 @@ func TestHandleCollationBodyRequests(t *testing.T) {
 	// Stores the collation into the inmemory kv store shardChainDB.
 	collation := sharding.NewCollation(header, body, nil)
 
-	shard := sharding.NewShard(shardID, shardChainDB)
+	shard := sharding.NewShard(shardID, shardChainDB.DB())
 
 	if err := shard.SaveCollation(collation); err != nil {
 		t.Fatalf("Could not store collation in shardChainDB: %v", err)

--- a/sharding/syncer/service_test.go
+++ b/sharding/syncer/service_test.go
@@ -1,7 +1,6 @@
 package syncer
 
 import (
-	"errors"
 	"fmt"
 	"math/big"
 	"strings"
@@ -10,7 +9,6 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/sharding/mainchain"
 
 	"github.com/ethereum/go-ethereum/sharding/p2p/messages"
 
@@ -20,42 +18,9 @@ import (
 	"github.com/ethereum/go-ethereum/sharding/database"
 	internal "github.com/ethereum/go-ethereum/sharding/internal"
 	"github.com/ethereum/go-ethereum/sharding/p2p"
-	"github.com/ethereum/go-ethereum/sharding/params"
 )
 
 var _ = sharding.Service(&Syncer{})
-
-func TestStartStop(t *testing.T) {
-	h := internal.NewLogHandler(t)
-	log.Root().SetHandler(h)
-
-	shardChainDB := database.NewShardKV()
-	shardID := 0
-	server, err := p2p.NewServer()
-	if err != nil {
-		t.Fatalf("Unable to setup p2p server: %v", err)
-	}
-
-	syncer, err := NewSyncer(params.DefaultConfig, &mainchain.SMCClient{}, server, shardChainDB, shardID)
-	if err != nil {
-		t.Fatalf("Unable to setup sync service: %v", err)
-	}
-
-	syncer.Start()
-
-	h.VerifyLogMsg("Starting sync service")
-
-	if err := syncer.Stop(); err != nil {
-		t.Fatalf("Unable to stop sync service: %v", err)
-	}
-
-	h.VerifyLogMsg("Stopping sync service")
-
-	// The context should have been canceled.
-	if syncer.ctx.Err() == nil {
-		t.Error("Context was not canceled")
-	}
-}
 
 // This test uses a faulty Signer interface in order to trigger an error
 // in the simulateNotaryRequests goroutine when attempting to sign
@@ -65,46 +30,32 @@ func TestHandleCollationBodyRequests_FaultySigner(t *testing.T) {
 	log.Root().SetHandler(h)
 
 	shardChainDB := database.NewShardKV()
-	shardID := 0
+	shardID := big.NewInt(0)
 	server, err := p2p.NewServer()
 	if err != nil {
 		t.Fatalf("Unable to setup p2p server: %v", err)
 	}
 
-	syncer, err := NewSyncer(params.DefaultConfig, &mainchain.SMCClient{}, server, shardChainDB, shardID)
-	if err != nil {
-		t.Fatalf("Unable to setup syncer service: %v", err)
-	}
-
+	msgChan := make(chan p2p.Message, 1)
 	feed := server.Feed(messages.CollationBodyRequest{})
+	shard := sharding.NewShard(shardID, shardChainDB)
+	done := make(chan struct{})
+	errChan := make(chan error)
+	sub := feed.Subscribe(msgChan)
 
-	go syncer.handleCollationBodyRequests(&faultySigner{}, feed)
+	go handleCollationBodyRequests(&faultySigner{}, shard, server, msgChan, done, sub, errChan)
 
-	go func() {
-		for {
-			select {
-			case <-syncer.ctx.Done():
-				return
-			default:
-				msg := p2p.Message{
-					Peer: p2p.Peer{},
-					Data: messages.CollationBodyRequest{},
-				}
-				feed.Send(msg)
-			}
-		}
-	}()
-
-	receivedErr := <-syncer.errChan
+	msg := p2p.Message{
+		Peer: p2p.Peer{},
+		Data: messages.CollationBodyRequest{},
+	}
+	msgChan <- msg
+	receivedErr := <-errChan
 	expectedErr := "could not construct response"
 	if !strings.Contains(receivedErr.Error(), expectedErr) {
 		t.Errorf("Expected error did not match. want: %v, got: %v", expectedErr, receivedErr)
 	}
-	syncer.cancel()
-	// The context should have been canceled.
-	if syncer.ctx.Err() == nil {
-		t.Fatal("Context was not canceled")
-	}
+	done <- struct{}{}
 }
 
 // This test checks the proper functioning of the handleCollationBodyRequests goroutine
@@ -145,88 +96,26 @@ func TestHandleCollationBodyRequests(t *testing.T) {
 		t.Fatalf("Could not store collation in shardChainDB: %v", err)
 	}
 
-	syncer, err := NewSyncer(params.DefaultConfig, &mainchain.SMCClient{}, server, shardChainDB, 0)
-	if err != nil {
-		t.Fatalf("Unable to setup syncer service: %v", err)
-	}
-
 	feed := server.Feed(messages.CollationBodyRequest{})
+	msgChan := make(chan p2p.Message, 1)
+	done := make(chan struct{})
+	errChan := make(chan error)
+	sub := feed.Subscribe(msgChan)
 
-	go syncer.handleCollationBodyRequests(&mockSigner{}, feed)
+	go handleCollationBodyRequests(&mockSigner{}, shard, server, msgChan, done, sub, errChan)
 
-	go func() {
-		for {
-			select {
-			case <-syncer.ctx.Done():
-				return
-			default:
-				msg := p2p.Message{
-					Peer: p2p.Peer{},
-					Data: messages.CollationBodyRequest{
-						ChunkRoot: &chunkRoot,
-						ShardID:   shardID,
-						Period:    period,
-						Proposer:  &proposerAddress,
-					},
-				}
-				feed.Send(msg)
-			}
-		}
-	}()
-
-	<-syncer.responseSent
+	msg := p2p.Message{
+		Peer: p2p.Peer{},
+		Data: messages.CollationBodyRequest{
+			ChunkRoot: &chunkRoot,
+			ShardID:   shardID,
+			Period:    period,
+			Proposer:  &proposerAddress,
+		},
+	}
+	msgChan <- msg
+	done <- struct{}{}
+	time.Sleep(time.Second * 5)
 	h.VerifyLogMsg(fmt.Sprintf("Received p2p request of type: %T", p2p.Message{}))
 	h.VerifyLogMsg(fmt.Sprintf("Responding to p2p request with collation with headerHash: %v", header.Hash().Hex()))
-	syncer.cancel()
-	// The context should have been canceled.
-	if syncer.ctx.Err() == nil {
-		t.Fatal("Context was not canceled")
-	}
-}
-
-// TODO: Move this to the utils package along with the handleServiceErrors
-// function.
-func TestHandleServiceErrors(t *testing.T) {
-
-	h := internal.NewLogHandler(t)
-	log.Root().SetHandler(h)
-
-	shardChainDB := database.NewShardKV()
-	shardID := 0
-	server, err := p2p.NewServer()
-	if err != nil {
-		t.Fatalf("Unable to setup p2p server: %v", err)
-	}
-
-	syncer, err := NewSyncer(params.DefaultConfig, &mainchain.SMCClient{}, server, shardChainDB, shardID)
-	if err != nil {
-		t.Fatalf("Unable to setup syncer service: %v", err)
-	}
-
-	go syncer.handleServiceErrors()
-
-	expectedErr := "testing the error channel"
-	complete := make(chan int)
-
-	go func() {
-		for {
-			select {
-			case <-syncer.ctx.Done():
-				return
-			default:
-				syncer.errChan <- errors.New(expectedErr)
-				complete <- 1
-			}
-		}
-	}()
-
-	<-complete
-	syncer.cancel()
-
-	// The context should have been canceled.
-	if syncer.ctx.Err() == nil {
-		t.Fatal("Context was not canceled")
-	}
-	time.Sleep(time.Millisecond * 500)
-	h.VerifyLogMsg(fmt.Sprintf("Sync service error: %v", expectedErr))
 }

--- a/sharding/utils/service.go
+++ b/sharding/utils/service.go
@@ -1,0 +1,21 @@
+package utils
+
+import (
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/log"
+)
+
+// HandleServiceErrors manages a goroutine that listens for errors broadcast to
+// this service's error channel. This serves as a final step for error logging
+// and is stopped upon the service shutting down.
+func HandleServiceErrors(done <-chan struct{}, errChan <-chan error) {
+	for {
+		select {
+		case <-done:
+			return
+		case err := <-errChan:
+			log.Error(fmt.Sprint(err))
+		}
+	}
+}

--- a/sharding/utils/service.go
+++ b/sharding/utils/service.go
@@ -1,8 +1,6 @@
 package utils
 
 import (
-	"fmt"
-
 	"github.com/ethereum/go-ethereum/log"
 )
 
@@ -15,7 +13,7 @@ func HandleServiceErrors(done <-chan struct{}, errChan <-chan error) {
 		case <-done:
 			return
 		case err := <-errChan:
-			log.Error(fmt.Sprint(err))
+			log.Error(err.Error())
 		}
 	}
 }

--- a/sharding/utils/service_test.go
+++ b/sharding/utils/service_test.go
@@ -1,0 +1,22 @@
+package utils
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/sharding/internal"
+)
+
+func TestHandleServiceErrors(t *testing.T) {
+	h := internal.NewLogHandler(t)
+	log.Root().SetHandler(h)
+	done := make(chan struct{})
+	errChan := make(chan error)
+
+	go HandleServiceErrors(done, errChan)
+
+	errChan <- errors.New("something wrong")
+	done <- struct{}{}
+	h.VerifyLogMsg("something wrong")
+}


### PR DESCRIPTION
Hi all,

This resolves #197. Previously, we were using the following pattern in goroutines which made testing a bit hard.

```go
func (s *Syncer) someGoroutine(arg1, arg2, arg3, arg4, ..) {
	ch := make(chan p2p.Message, 100)
	for {
		select {
		// Makes sure to close this goroutine when the service stops.
		case <-arg1:
			return
		case req := <-arg2
                         doStuff(arg3, arg4)
                 }
        }
}
```

We had a massive number of arguments to our functions where we could have simply been using their associated struct fields and mocking them during the testing process. This PR fixes this issue. Props to @rawfalafel for pointing in the right direction.
