### PR TITLE
Add debug flags to shardingcmd

### DIFF
--- a/cmd/geth/shardingcmd.go
+++ b/cmd/geth/shardingcmd.go
@@ -4,17 +4,19 @@ import (
 	"fmt"
 
 	"github.com/ethereum/go-ethereum/cmd/utils"
+	"github.com/ethereum/go-ethereum/internal/debug"
 	node "github.com/ethereum/go-ethereum/sharding/node"
 	cli "gopkg.in/urfave/cli.v1"
 )
 
 var (
+	flags           = []cli.Flag{utils.ActorFlag, utils.DataDirFlag, utils.PasswordFileFlag, utils.NetworkIdFlag, utils.IPCPathFlag, utils.DepositFlag, utils.ShardIDFlag}
 	shardingCommand = cli.Command{
 		Action:    utils.MigrateFlags(shardingCmd),
 		Name:      "sharding",
 		Usage:     "Start a sharding-enabled node",
 		ArgsUsage: "[endpoint]",
-		Flags:     []cli.Flag{utils.ActorFlag, utils.DataDirFlag, utils.PasswordFileFlag, utils.NetworkIdFlag, utils.IPCPathFlag, utils.DepositFlag, utils.ShardIDFlag},
+		Flags:     append(flags, debug.Flags...),
 		Category:  "SHARDING COMMANDS",
 		Description: `
 Launches a sharding node that manages services related to submitting collations to a Sharding Manager Contract, notary and proposer services, and shardp2p connections. This feature is a work in progress.
@@ -26,6 +28,10 @@ Launches a sharding node that manages services related to submitting collations 
 // A sharding node launches a suite of services including notary services,
 // proposer services, and a shardp2p protocol.
 func shardingCmd(ctx *cli.Context) error {
+	if err := debug.Setup(ctx); err != nil {
+		return err
+	}
+
 	// configures a sharding-enabled node using the cli's context.
 	shardingNode, err := node.New(ctx)
 	if err != nil {


### PR DESCRIPTION
This gives the sharding command the following functionality:

```
LOGGING AND DEBUGGING OPTIONS:
  --verbosity value         Logging verbosity: 0=silent, 1=error, 2=warn, 3=info, 4=debug, 5=detail (default: 3)
  --vmodule value           Per-module verbosity: comma-separated list of <pattern>=<level> (e.g. eth/*=5,p2p=4)
  --backtrace value         Request a stack trace at a specific logging statement (e.g. "block.go:271")
  --debug                   Prepends log messages with call-site location (file and line number)
  --pprof                   Enable the pprof HTTP server
  --pprofaddr value         pprof HTTP server listening interface (default: "127.0.0.1")
  --pprofport value         pprof HTTP server listening port (default: 6060)
  --memprofilerate value    Turn on memory profiling with the given rate (default: 524288)
  --blockprofilerate value  Turn on block profiling with the given rate (default: 0)
  --cpuprofile value        Write CPU profile to the given file
  --trace value             Write execution trace to the given file
```

Most helpful is the `--debug` flag which will indicate the file names and line numbers of logging statements and `--verbosity=4` for lower level messages.