### PR TITLE
Check AddHeader Transaction Gets Mined

### DIFF
--- a/sharding/proposer/proposer.go
+++ b/sharding/proposer/proposer.go
@@ -1,6 +1,7 @@
 package proposer
 
 import (
+	"context"
 	"fmt"
 	"math/big"
 
@@ -10,7 +11,6 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/sharding"
 	"github.com/ethereum/go-ethereum/sharding/mainchain"
-	"context"
 )
 
 // AddHeader adds the collation header to the main chain by sending

--- a/sharding/proposer/service.go
+++ b/sharding/proposer/service.go
@@ -115,7 +115,7 @@ func (p *Proposer) createCollation(ctx context.Context, txs []*types.Transaction
 		return err
 	}
 	if canAdd {
-		AddHeader(p.client, collation)
+		AddHeader(p.client, p.client, collation)
 	}
 
 	return nil

--- a/sharding/proposer/service_test.go
+++ b/sharding/proposer/service_test.go
@@ -98,7 +98,7 @@ func TestAddCollation(t *testing.T) {
 	}
 
 	// normal test case #1 create collation with normal parameters.
-	err = AddHeader(node, collation)
+	err = AddHeader(node, node, collation)
 	if err != nil {
 		t.Errorf("%v", err)
 	}
@@ -144,7 +144,7 @@ func TestCheckCollation(t *testing.T) {
 		backend.Commit()
 	}
 
-	err = AddHeader(node, collation)
+	err = AddHeader(node, node, collation)
 	if err != nil {
 		t.Errorf("%v", err)
 	}

--- a/sharding/proposer/service_test.go
+++ b/sharding/proposer/service_test.go
@@ -1,21 +1,15 @@
 package proposer
 
 import (
-	"context"
 	"crypto/rand"
 	"math/big"
 	"testing"
-	"time"
 
-	"github.com/ethereum/go-ethereum"
-	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
-	"github.com/ethereum/go-ethereum/accounts/abi/bind/backends"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
-	"github.com/ethereum/go-ethereum/sharding/contracts"
+	"github.com/ethereum/go-ethereum/sharding/internal"
 	"github.com/ethereum/go-ethereum/sharding/params"
 )
 
@@ -25,73 +19,9 @@ var (
 	accountBalance, _ = new(big.Int).SetString("1001000000000000000000", 10)
 )
 
-// Mock client for testing proposer.
-type mockNode struct {
-	smc         *contracts.SMC
-	t           *testing.T
-	depositFlag bool
-	backend     *backends.SimulatedBackend
-}
-
-func (m *mockNode) Account() *accounts.Account {
-	return &accounts.Account{Address: addr}
-}
-
-func (m *mockNode) SMCCaller() *contracts.SMCCaller {
-	return &m.smc.SMCCaller
-}
-
-func (m *mockNode) ChainReader() ethereum.ChainReader {
-	return nil
-}
-
-func (m *mockNode) SMCTransactor() *contracts.SMCTransactor {
-	return &m.smc.SMCTransactor
-}
-
-func (m *mockNode) SMCFilterer() *contracts.SMCFilterer {
-	return &m.smc.SMCFilterer
-}
-
-func (m *mockNode) WaitForTransaction(ctx context.Context, hash common.Hash, durationInSeconds time.Duration) error {
-	return nil
-}
-
-func (m *mockNode) TransactionReceipt(hash common.Hash) (*types.Receipt, error) {
-	return nil, nil
-}
-
-func (m *mockNode) CreateTXOpts(value *big.Int) (*bind.TransactOpts, error) {
-	txOpts := transactOpts()
-	txOpts.Value = value
-	return txOpts, nil
-}
-
-func (m *mockNode) Sign(hash common.Hash) ([]byte, error) {
-	return nil, nil
-}
-
-func (m *mockNode) GetShardCount() (int64, error) {
-	return 100, nil
-}
-
-func transactOpts() *bind.TransactOpts {
-	return bind.NewKeyedTransactor(key)
-}
-
-func setup(t *testing.T) (*backends.SimulatedBackend, *contracts.SMC) {
-	backend := backends.NewSimulatedBackend(core.GenesisAlloc{addr: {Balance: accountBalance}})
-	_, _, smc, err := contracts.DeploySMC(transactOpts(), backend)
-	if err != nil {
-		t.Fatalf("Failed to deploy SMC contract: %v", err)
-	}
-	backend.Commit()
-	return backend, smc
-}
-
 func TestCreateCollation(t *testing.T) {
-	backend, smc := setup(t)
-	node := &mockNode{smc: smc, t: t, backend: backend}
+	backend, smc := internal.SetupMockClient(t)
+	node := &internal.MockClient{SMC: smc, T: t, Backend: backend}
 	var txs []*types.Transaction
 	for i := 0; i < 10; i++ {
 		data := make([]byte, 1024)
@@ -148,8 +78,8 @@ func TestCreateCollation(t *testing.T) {
 }
 
 func TestAddCollation(t *testing.T) {
-	backend, smc := setup(t)
-	node := &mockNode{smc: smc, t: t, backend: backend}
+	backend, smc := internal.SetupMockClient(t)
+	node := &internal.MockClient{SMC: smc, T: t, Backend: backend}
 	var txs []*types.Transaction
 	for i := 0; i < 10; i++ {
 		data := make([]byte, 1024)
@@ -196,8 +126,8 @@ func TestAddCollation(t *testing.T) {
 }
 
 func TestCheckCollation(t *testing.T) {
-	backend, smc := setup(t)
-	node := &mockNode{smc: smc, t: t, backend: backend}
+	backend, smc := internal.SetupMockClient(t)
+	node := &internal.MockClient{SMC: smc, T: t, Backend: backend}
 	var txs []*types.Transaction
 	for i := 0; i < 10; i++ {
 		data := make([]byte, 1024)

--- a/sharding/syncer/handlers_test.go
+++ b/sharding/syncer/handlers_test.go
@@ -2,10 +2,13 @@ package syncer
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"math/big"
 	"testing"
+	"time"
 
+	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind/backends"
 	"github.com/ethereum/go-ethereum/common"
@@ -17,6 +20,7 @@ import (
 	"github.com/ethereum/go-ethereum/sharding/p2p"
 	"github.com/ethereum/go-ethereum/sharding/p2p/messages"
 	"github.com/ethereum/go-ethereum/sharding/params"
+	shardparams "github.com/ethereum/go-ethereum/sharding/params"
 	"github.com/ethereum/go-ethereum/sharding/proposer"
 )
 
@@ -31,7 +35,8 @@ type mockNode struct {
 	smc         *contracts.SMC
 	t           *testing.T
 	depositFlag bool
-	backend     *backends.SimulatedBackend
+	Backend     *backends.SimulatedBackend
+	BlockNumber int64
 }
 
 type faultySMCCaller struct{}
@@ -71,6 +76,39 @@ func (m *mockNode) GetShardCount() (int64, error) {
 		return 0, err
 	}
 	return shardCount.Int64(), nil
+}
+
+func (m *mockNode) Account() *accounts.Account {
+	return &accounts.Account{Address: addr}
+}
+
+func (m *mockNode) WaitForTransaction(ctx context.Context, hash common.Hash, durationInSeconds time.Duration) error {
+	m.CommitWithBlock()
+	m.FastForward(1)
+	return nil
+}
+
+func (m *mockNode) TransactionReceipt(hash common.Hash) (*types.Receipt, error) {
+	return m.Backend.TransactionReceipt(context.Background(), hash)
+}
+
+func (m *mockNode) DepositFlag() bool {
+	return m.depositFlag
+}
+
+func (m *mockNode) FastForward(p int) {
+	for i := 0; i < p*int(shardparams.DefaultConfig.PeriodLength); i++ {
+		m.CommitWithBlock()
+	}
+}
+
+func (m *mockNode) CommitWithBlock() {
+	m.Backend.Commit()
+	m.BlockNumber = m.BlockNumber + 1
+}
+
+func (m *mockNode) BlockByNumber(ctx context.Context, number *big.Int) (*types.Block, error) {
+	return types.NewBlockWithHeader(&types.Header{Number: big.NewInt(m.BlockNumber)}), nil
 }
 
 type faultyRequest struct{}
@@ -176,7 +214,7 @@ func TestCollationBodyResponse(t *testing.T) {
 func TestConstructNotaryRequest(t *testing.T) {
 
 	backend, smc := setup(t)
-	node := &mockNode{smc: smc, t: t, backend: backend}
+	node := &mockNode{smc: smc, t: t, Backend: backend}
 
 	// Fast forward to next period.
 	for i := 0; i < int(params.DefaultConfig.PeriodLength); i++ {
@@ -193,7 +231,7 @@ func TestConstructNotaryRequest(t *testing.T) {
 	collation := sharding.NewCollation(header, []byte{}, []*types.Transaction{})
 
 	// Adds the header to the SMC.
-	if err := proposer.AddHeader(node, collation); err != nil {
+	if err := proposer.AddHeader(node, node, collation); err != nil {
 		t.Fatalf("Failed to add header to SMC: %v", err)
 	}
 


### PR DESCRIPTION
This fixes #209. When we send an addHeader transaction, we don't check whether the transaction gets mined before proceeding to the next step. This PR addressed the bug by adding a `WaitForTransaction` function after `AddHeader` gets called. The `WaitForTransaction` time out duration is set for 5 minutes for Ruby Release. The `AddHeader` logic will change when we bring in beacon chain, let's not worry on the hard coded time out.