### PR TITLE
Notaries are able to handle collation body responses and vote on them 

### DIFF
--- a/sharding/notary/notary.go
+++ b/sharding/notary/notary.go
@@ -494,3 +494,19 @@ func submitVote(shard sharding.Shard, manager mainchain.ContractManager, client 
 
 	return err
 }
+
+func RequestCollation(shard sharding.Shard, Proposer *common.Address, Period *big.Int, ChunkRoot *common.Hash) (*sharding.Collation, error) {
+
+}
+
+func CalculatePOCAndVote(c *sharding.Collation, s *sharding.Shard) error {
+
+}
+
+func AddCanonicalCollation(s *sharding.Shard) error {
+
+}
+
+func CollationStore(c *sharding.Collation, s *sharding.Shard) error {
+
+}


### PR DESCRIPTION
## Objective
The objective of the PR is for notaries to be able to persist with collation body responses from other nodes to vote on data availability. This will address and close #205
## Background
Currently notaries are able to create requests for collation bodies and broadcast them to shard p2p. However upon receiving the collation bodies they do not do anything with them. In this design document we will deal with how to track the response, persist with them in local storage and vote on the collation
More information and context is defined in the [design doc](https://docs.google.com/document/d/1JDNg1n7uRW5kes0uu0DBzAT4kiDZO4xGlqHq5pvCZNA/edit#heading=h.atpdjtp6sink)
## Requirements for Merge
- [ ] Implement all the functions required for notaries to create requests for collation bodies , persist with them and vote on their data availibility. 
- [ ] Write appropriate tests for both happy and sad cases
