### PR TITLE
Fix race condition in simulator tests

### DIFF
--- a/sharding/internal/log_helper.go
+++ b/sharding/internal/log_helper.go
@@ -41,6 +41,7 @@ func (t *LogHandler) Len() int {
 func (h *LogHandler) VerifyLogMsg(str string) {
 	if h.Len() == 0 {
 		h.t.Error("Expected a log, but there were none!")
+		return
 	}
 	if l := h.Pop(); l.Msg != str {
 		h.t.Errorf("Unexpected log: %v. Wanted: %s", l.Msg, str)

--- a/sharding/simulator/service.go
+++ b/sharding/simulator/service.go
@@ -13,7 +13,6 @@ import (
 	"github.com/prysmaticlabs/geth-sharding/sharding/p2p/messages"
 	"github.com/prysmaticlabs/geth-sharding/sharding/params"
 	"github.com/prysmaticlabs/geth-sharding/sharding/syncer"
-	"github.com/prysmaticlabs/geth-sharding/sharding/utils"
 )
 
 // Simulator is a service in a shard node that simulates requests from
@@ -29,7 +28,6 @@ type Simulator struct {
 	shardID     int
 	ctx         context.Context
 	cancel      context.CancelFunc
-	errChan     chan error // Useful channel for handling errors at the service layer.
 	delay       time.Duration
 	requestFeed *event.Feed
 }
@@ -39,8 +37,7 @@ type Simulator struct {
 // and a shardID.
 func NewSimulator(config *params.Config, client *mainchain.SMCClient, p2p *p2p.Server, shardID int, delay time.Duration) (*Simulator, error) {
 	ctx, cancel := context.WithCancel(context.Background())
-	errChan := make(chan error)
-	return &Simulator{config, client, p2p, shardID, ctx, cancel, errChan, delay, nil}, nil
+	return &Simulator{config, client, p2p, shardID, ctx, cancel, delay, nil}, nil
 }
 
 // Start the main loop for simulating p2p requests.
@@ -48,8 +45,7 @@ func (s *Simulator) Start() {
 	log.Info("Starting simulator service")
 
 	s.requestFeed = s.p2p.Feed(messages.CollationBodyRequest{})
-	go utils.HandleServiceErrors(s.ctx.Done(), s.errChan)
-	go s.simulateNotaryRequests(s.client.SMCCaller(), s.client.ChainReader(), time.Tick(time.Second*s.delay))
+	go s.simulateNotaryRequests(s.client.SMCCaller(), s.client.ChainReader(), time.Tick(time.Second*s.delay), s.ctx.Done())
 }
 
 // Stop the main loop for simulator requests.
@@ -57,7 +53,6 @@ func (s *Simulator) Stop() error {
 	// Triggers a cancel call in the service's context which shuts down every goroutine
 	// in this service.
 	defer s.cancel()
-	defer close(s.errChan)
 	log.Warn("Stopping simulator service")
 	return nil
 }
@@ -68,24 +63,24 @@ func (s *Simulator) Stop() error {
 // pair to perform their responsibilities. This function in particular simulates
 // requests for collation bodies that will be relayed to the appropriate proposer
 // by the p2p feed layer.
-func (s *Simulator) simulateNotaryRequests(fetcher mainchain.RecordFetcher, reader mainchain.Reader, delayChan <-chan time.Time) {
+func (s *Simulator) simulateNotaryRequests(fetcher mainchain.RecordFetcher, reader mainchain.Reader, delayChan <-chan time.Time, done <-chan struct{}) {
 	for {
 		select {
 		// Makes sure to close this goroutine when the service stops.
-		case <-s.ctx.Done():
+		case <-done:
 			log.Debug("Simulator context closed, exiting goroutine")
 			return
 		case <-delayChan:
 			blockNumber, err := reader.BlockByNumber(s.ctx, nil)
 			if err != nil {
-				s.errChan <- fmt.Errorf("could not fetch current block number: %v", err)
+				log.Error(fmt.Sprintf("Could not fetch current block number: %v", err))
 				continue
 			}
 
 			period := new(big.Int).Div(blockNumber.Number(), big.NewInt(s.config.PeriodLength))
 			req, err := syncer.RequestCollationBody(fetcher, big.NewInt(int64(s.shardID)), period)
 			if err != nil {
-				s.errChan <- fmt.Errorf("error constructing collation body request: %v", err)
+				log.Error(fmt.Sprintf("Error constructing collation body request: %v", err))
 				continue
 			}
 			if req != nil {


### PR DESCRIPTION
Here's the race condition causing the tests to be flaky:
```
simulator.cancel()
// The context should have been canceled.
if simulator.ctx.Err() == nil {
  t.Error("Context was not canceled")
}
```

The docs for [CancelFunc](https://golang.org/pkg/context/#CancelFunc) state that `cancel` is non-blocking, meaning that the next line in the test isn't guaranteed to run after `cancel` executes. So what's the fix? Pass the channel returned by `ctx.Done()` into the goroutine and control the channel in the test. Here's what that would look like:

```
doneChan := make(chan, struct{})
go simulator.simulateNotaryRequests(..., doneChan)

doneChan <- struct{}{} // this is equivalent to simulator.cancel()
h.VerifyLogMsg("Simulator context closed, exiting goroutine") // check logs instead of ctx.Err()
```

Now we've converted `simulator.cancel()` into a blocking call, but there's actually another race condition. The log message comes after `doneChan` receives an item in [these two lines](https://github.com/rawfalafel/geth-sharding/blob/6f1ed0645073e542a3a5aa7c0e92535feef69838/sharding/simulator/service.go#L70-L71), and so there's a chance that `VerifyLogMsg` gets called before the log message gets handled. What we really want is to block until the goroutine exits completely. How do we do that? By modifying the goroutine in the test and including a blocking channel.

```
doneChan := make(chan, struct{})
exitRoutine := make(chan, bool)
go func() {
  simulator.simulateNotaryRequests(..., doneChan)
  <-exitRoutine
}()

doneChan <- struct{}{}
exitRoutine <- true
h.VerifyLogMsg("Simulator context closed, exiting goroutine")
```

This guarantees that `VerifyLogMsg` gets called after the log message, eliminating all race conditions. An important side-effect of including `exitRoutine` is that this guarantees that the goroutine exits before the test reaches the end, freeing up resources for the garbage collector.

Here's the general takeaway moving forward when testing goroutines, particularly ones in an infinite loop like our service goroutines.
1. Test the function calling the goroutine first (`Start` and `Stop` functions in our case)
2. Test the goroutine itself, and pass in the channels as arguments so that the test has full control of the code's asynchronicity.
3. Guarantee that the goroutine exits by including an `exitRoutine` channel 

