### PR TITLE
Disable remote caching for now on Travis

### DIFF
--- a/.travis-bazelrc
+++ b/.travis-bazelrc
@@ -5,8 +5,8 @@ startup --host_jvm_args=-Xmx500m --host_jvm_args=-Xms500m
 build --spawn_strategy=standalone --genrule_strategy=standalone
 
 # Remote caching over Google Cloud Storage
-build --remote_http_cache=https://storage.googleapis.com/prysmatic-bazel-cache 
-build --google_credentials=/tmp/service-account.json
+#build --remote_http_cache=https://storage.googleapis.com/prysmatic-bazel-cache 
+#build --google_credentials=/tmp/service-account.json
 
 # Set some build options for travis container.
 build --local_resources=1536,1.5,0.5


### PR DESCRIPTION
This is blocking other PRs so lets remove it until it can be resolved effectively. 