### PR TITLE
Abstract Service Registry Into Shared Folder, Add Beacon Node and Beacon Entry Point

### DIFF
--- a/beacon-chain/BUILD.bazel
+++ b/beacon-chain/BUILD.bazel
@@ -1,8 +1,18 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 
 go_library(
     name = "go_default_library",
-    srcs = ["config.go"],
+    srcs = ["main.go"],
     importpath = "github.com/prysmaticlabs/geth-sharding/beacon-chain",
     visibility = ["//beacon-chain:__subpackages__"],
+    deps = [
+        "//beacon-chain/node:go_default_library",
+        "@com_github_urfave_cli//:go_default_library",
+    ],
+)
+
+go_binary(
+    name = "beacon-chain",
+    embed = [":go_default_library"],
+    visibility = ["//visibility:public"],
 )

--- a/beacon-chain/BUILD.bazel
+++ b/beacon-chain/BUILD.bazel
@@ -14,5 +14,5 @@ go_library(
 go_binary(
     name = "beacon-chain",
     embed = [":go_default_library"],
-    visibility = ["//visibility:public"],
+    visibility = ["//beacon-chain:__subpackages__"],
 )

--- a/beacon-chain/BUILD.bazel
+++ b/beacon-chain/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//beacon-chain:__subpackages__"],
     deps = [
         "//beacon-chain/node:go_default_library",
+        "@com_github_sirupsen_logrus//:go_default_library",
         "@com_github_urfave_cli//:go_default_library",
     ],
 )

--- a/beacon-chain/main.go
+++ b/beacon-chain/main.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"runtime"
+
+	"github.com/prysmaticlabs/geth-sharding/beacon-chain/node"
+	"github.com/urfave/cli"
+)
+
+func startNode(ctx *cli.Context) error {
+	beacon, err := node.New(ctx)
+	if err != nil {
+		return err
+	}
+	// starts a connection to a beacon node and kicks off every registered service.
+	beacon.Start()
+	return nil
+}
+
+func main() {
+	app := cli.NewApp()
+	app.Name = "beacon-chain"
+	app.Usage = "this is a beacon chain implementation for Ethereum 2.0"
+	app.Action = startNode
+
+	app.Before = func(ctx *cli.Context) error {
+		runtime.GOMAXPROCS(runtime.NumCPU())
+		return nil
+	}
+
+	if err := app.Run(os.Args); err != nil {
+		if _, err := fmt.Fprintln(os.Stderr, err); err != nil {
+			panic(err)
+		}
+		os.Exit(1)
+	}
+}

--- a/beacon-chain/main.go
+++ b/beacon-chain/main.go
@@ -1,11 +1,11 @@
 package main
 
 import (
-	"fmt"
 	"os"
 	"runtime"
 
 	"github.com/prysmaticlabs/geth-sharding/beacon-chain/node"
+	log "github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 )
 
@@ -14,7 +14,6 @@ func startNode(ctx *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	// starts a connection to a beacon node and kicks off every registered service.
 	beacon.Start()
 	return nil
 }
@@ -31,9 +30,7 @@ func main() {
 	}
 
 	if err := app.Run(os.Args); err != nil {
-		if _, err := fmt.Fprintln(os.Stderr, err); err != nil {
-			panic(err)
-		}
+		log.Error(err.Error())
 		os.Exit(1)
 	}
 }

--- a/beacon-chain/node/BUILD.bazel
+++ b/beacon-chain/node/BUILD.bazel
@@ -4,7 +4,7 @@ go_library(
     name = "go_default_library",
     srcs = ["node.go"],
     importpath = "github.com/prysmaticlabs/geth-sharding/beacon-chain/node",
-    visibility = ["//visibility:public"],
+    visibility = ["//beacon-chain:__subpackages__"],
     deps = [
         "//shared:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",

--- a/beacon-chain/node/BUILD.bazel
+++ b/beacon-chain/node/BUILD.bazel
@@ -1,0 +1,20 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["node.go"],
+    importpath = "github.com/prysmaticlabs/geth-sharding/beacon-chain/node",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//shared:go_default_library",
+        "@com_github_sirupsen_logrus//:go_default_library",
+        "@com_github_urfave_cli//:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["node_test.go"],
+    embed = [":go_default_library"],
+    deps = ["@com_github_urfave_cli//:go_default_library"],
+)

--- a/beacon-chain/node/node.go
+++ b/beacon-chain/node/node.go
@@ -1,0 +1,79 @@
+package node
+
+import (
+	"os"
+	"os/signal"
+	"sync"
+	"syscall"
+
+	"github.com/prysmaticlabs/geth-sharding/shared"
+	log "github.com/sirupsen/logrus"
+	"github.com/urfave/cli"
+)
+
+// BeaconNode defines a struct that handles the services running a random beacon chain
+// full PoS node. It handles the lifecycle of the entire system and registers
+// services to a service registry.
+type BeaconNode struct {
+	services *shared.ServiceRegistry
+	lock     sync.RWMutex
+	stop     chan struct{} // Channel to wait for termination notifications
+}
+
+// New creates a new node instance, sets up configuration options, and registers
+// every required service to the node.
+func New(ctx *cli.Context) (*BeaconNode, error) {
+	registry := shared.NewServiceRegistry()
+	beacon := &BeaconNode{
+		services: registry,
+		stop:     make(chan struct{}),
+	}
+
+	return beacon, nil
+}
+
+// Start the BeaconNode and kicks off every registered service.
+func (b *BeaconNode) Start() {
+	b.lock.Lock()
+
+	log.Info("Starting beacon node")
+
+	// Starts every service attached to the beacon node's registry.
+	b.services.StartAll()
+
+	stop := b.stop
+	b.lock.Unlock()
+
+	go func() {
+		sigc := make(chan os.Signal, 1)
+		signal.Notify(sigc, syscall.SIGINT, syscall.SIGTERM)
+		defer signal.Stop(sigc)
+		<-sigc
+		log.Info("Got interrupt, shutting down...")
+		go b.Close()
+		for i := 10; i > 0; i-- {
+			<-sigc
+			if i > 1 {
+				log.Info("Already shutting down, interrupt more to panic.", "times", i-1)
+			}
+		}
+		// ensure trace and CPU profile data is flushed.
+		panic("Panic closing the beacon node")
+	}()
+
+	// Wait for stop channel to be closed
+	<-stop
+}
+
+// Close handles graceful shutdown of the system.
+func (b *BeaconNode) Close() {
+	b.lock.Lock()
+	defer b.lock.Unlock()
+
+	// Stops every service registered in the beacon node.
+	b.services.StopAll()
+	log.Info("Stopping beacon node")
+
+	// unblock n.Wait
+	close(b.stop)
+}

--- a/beacon-chain/node/node.go
+++ b/beacon-chain/node/node.go
@@ -38,7 +38,6 @@ func (b *BeaconNode) Start() {
 
 	log.Info("Starting beacon node")
 
-	// Starts every service attached to the beacon node's registry.
 	b.services.StartAll()
 
 	stop := b.stop
@@ -57,7 +56,7 @@ func (b *BeaconNode) Start() {
 				log.Info("Already shutting down, interrupt more to panic.", "times", i-1)
 			}
 		}
-		// ensure trace and CPU profile data is flushed.
+		// Ensure trace and CPU profile data is flushed.
 		panic("Panic closing the beacon node")
 	}()
 
@@ -70,10 +69,7 @@ func (b *BeaconNode) Close() {
 	b.lock.Lock()
 	defer b.lock.Unlock()
 
-	// Stops every service registered in the beacon node.
 	b.services.StopAll()
 	log.Info("Stopping beacon node")
-
-	// unblock n.Wait
 	close(b.stop)
 }

--- a/beacon-chain/node/node.go
+++ b/beacon-chain/node/node.go
@@ -56,7 +56,6 @@ func (b *BeaconNode) Start() {
 				log.Info("Already shutting down, interrupt more to panic.", "times", i-1)
 			}
 		}
-		// Ensure trace and CPU profile data is flushed.
 		panic("Panic closing the beacon node")
 	}()
 

--- a/beacon-chain/node/node.go
+++ b/beacon-chain/node/node.go
@@ -17,7 +17,7 @@ import (
 type BeaconNode struct {
 	services *shared.ServiceRegistry
 	lock     sync.RWMutex
-	stop     chan struct{} // Channel to wait for termination notifications
+	stop     chan struct{} // Channel to wait for termination notifications.
 }
 
 // New creates a new node instance, sets up configuration options, and registers
@@ -60,7 +60,7 @@ func (b *BeaconNode) Start() {
 		panic("Panic closing the beacon node")
 	}()
 
-	// Wait for stop channel to be closed
+	// Wait for stop channel to be closed.
 	<-stop
 }
 

--- a/beacon-chain/node/node_test.go
+++ b/beacon-chain/node/node_test.go
@@ -1,7 +1,6 @@
 package node
 
 import (
-	"flag"
 	"testing"
 
 	"github.com/urfave/cli"
@@ -10,12 +9,10 @@ import (
 // Test that the sharding node can build with default flag values.
 func TestNode_Builds(t *testing.T) {
 	app := cli.NewApp()
-	set := flag.NewFlagSet("test", 0)
-
-	context := cli.NewContext(app, set, nil)
+	context := cli.NewContext(app, nil, nil)
 
 	_, err := New(context)
 	if err != nil {
-		t.Fatalf("Failed to create ShardEthereum: %v", err)
+		t.Fatalf("Failed to create BeaconNode: %v", err)
 	}
 }

--- a/beacon-chain/params/BUILD.bazel
+++ b/beacon-chain/params/BUILD.bazel
@@ -1,0 +1,8 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["config.go"],
+    importpath = "github.com/prysmaticlabs/geth-sharding/beacon-chain/params",
+    visibility = ["//visibility:public"],
+)

--- a/beacon-chain/params/BUILD.bazel
+++ b/beacon-chain/params/BUILD.bazel
@@ -4,5 +4,5 @@ go_library(
     name = "go_default_library",
     srcs = ["config.go"],
     importpath = "github.com/prysmaticlabs/geth-sharding/beacon-chain/params",
-    visibility = ["//visibility:public"],
+    visibility = ["//beacon-chain:__subpackages__"],
 )

--- a/beacon-chain/params/config.go
+++ b/beacon-chain/params/config.go
@@ -1,4 +1,4 @@
-package beacon
+package params
 
 const (
 	// AttesterCount is the number of attesters per committee/

--- a/sharding/BUILD.bazel
+++ b/sharding/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "github.com/prysmaticlabs/geth-sharding/sharding",
     visibility = ["//sharding:__subpackages__"],
     deps = [
+        "//bazel-geth-sharding/external/com_github_ethereum_go_ethereum/log:go_default_library",
         "//sharding/node:go_default_library",
         "//sharding/utils:go_default_library",
         "@com_github_urfave_cli//:go_default_library",

--- a/sharding/BUILD.bazel
+++ b/sharding/BUILD.bazel
@@ -6,9 +6,9 @@ go_library(
     importpath = "github.com/prysmaticlabs/geth-sharding/sharding",
     visibility = ["//sharding:__subpackages__"],
     deps = [
-        "//bazel-geth-sharding/external/com_github_ethereum_go_ethereum/log:go_default_library",
         "//sharding/node:go_default_library",
         "//sharding/utils:go_default_library",
+        "@com_github_sirupsen_logrus//:go_default_library",
         "@com_github_urfave_cli//:go_default_library",
     ],
 )

--- a/sharding/main.go
+++ b/sharding/main.go
@@ -1,10 +1,10 @@
 package main
 
 import (
-	"fmt"
 	"os"
 	"runtime"
 
+	"github.com/prysmaticlabs/geth-sharding/bazel-geth-sharding/external/com_github_ethereum_go_ethereum/log"
 	"github.com/prysmaticlabs/geth-sharding/sharding/node"
 	"github.com/prysmaticlabs/geth-sharding/sharding/utils"
 	"github.com/urfave/cli"
@@ -61,9 +61,7 @@ VERSION:
 	}
 
 	if err := app.Run(os.Args); err != nil {
-		if _, err := fmt.Fprintln(os.Stderr, err); err != nil {
-			panic(err)
-		}
+		log.Error(err.Error())
 		os.Exit(1)
 	}
 }

--- a/sharding/main.go
+++ b/sharding/main.go
@@ -4,9 +4,9 @@ import (
 	"os"
 	"runtime"
 
-	"github.com/prysmaticlabs/geth-sharding/bazel-geth-sharding/external/com_github_ethereum_go_ethereum/log"
 	"github.com/prysmaticlabs/geth-sharding/sharding/node"
 	"github.com/prysmaticlabs/geth-sharding/sharding/utils"
+	log "github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 )
 

--- a/sharding/node/BUILD.bazel
+++ b/sharding/node/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
         "//sharding/txpool:go_default_library",
         "//sharding/types:go_default_library",
         "//sharding/utils:go_default_library",
+        "//shared:go_default_library",
         "@com_github_ethereum_go_ethereum//event:go_default_library",
         "@com_github_ethereum_go_ethereum//node:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
@@ -29,9 +30,5 @@ go_test(
     name = "go_default_test",
     srcs = ["backend_test.go"],
     embed = [":go_default_library"],
-    deps = [
-        "//sharding/params:go_default_library",
-        "//sharding/types:go_default_library",
-        "@com_github_urfave_cli//:go_default_library",
-    ],
+    deps = ["@com_github_urfave_cli//:go_default_library"],
 )

--- a/sharding/node/backend.go
+++ b/sharding/node/backend.go
@@ -99,8 +99,6 @@ func (s *ShardEthereum) Start() {
 
 	log.Info("Starting sharding node")
 
-	// Starts all services registered to the ShardEthereum instance in order of
-	// registration.
 	s.services.StartAll()
 
 	stop := s.stop
@@ -119,11 +117,11 @@ func (s *ShardEthereum) Start() {
 				log.Info("Already shutting down, interrupt more to panic.", "times", i-1)
 			}
 		}
-		// ensure trace and CPU profile data is flushed.
+		// Ensure trace and CPU profile data is flushed.
 		panic("Panic closing the sharding node")
 	}()
 
-	// Wait for stop channel to be closed
+	// Wait for stop channel to be closed.
 	<-stop
 }
 
@@ -132,11 +130,9 @@ func (s *ShardEthereum) Close() {
 	s.lock.Lock()
 	defer s.lock.Unlock()
 
-	// Stops all services registered to the ShardEthereum instance.
 	s.services.StopAll()
 	log.Info("Stopping sharding node")
 
-	// unblock n.Wait
 	close(s.stop)
 }
 
@@ -162,7 +158,6 @@ func (s *ShardEthereum) registerP2P() error {
 	return s.services.RegisterService(shardp2p)
 }
 
-// registerMainchainClient
 func (s *ShardEthereum) registerMainchainClient(ctx *cli.Context) error {
 	path := node.DefaultDataDir()
 	if ctx.GlobalIsSet(utils.DataDirFlag.Name) {

--- a/sharding/node/backend.go
+++ b/sharding/node/backend.go
@@ -117,7 +117,6 @@ func (s *ShardEthereum) Start() {
 				log.Info("Already shutting down, interrupt more to panic.", "times", i-1)
 			}
 		}
-		// Ensure trace and CPU profile data is flushed.
 		panic("Panic closing the sharding node")
 	}()
 

--- a/sharding/node/backend.go
+++ b/sharding/node/backend.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
-	"reflect"
 	"sync"
 	"syscall"
 	"time"
@@ -27,6 +26,7 @@ import (
 	"github.com/prysmaticlabs/geth-sharding/sharding/txpool"
 	"github.com/prysmaticlabs/geth-sharding/sharding/types"
 	"github.com/prysmaticlabs/geth-sharding/sharding/utils"
+	"github.com/prysmaticlabs/geth-sharding/shared"
 	log "github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 )
@@ -43,17 +43,17 @@ type ShardEthereum struct {
 	eventFeed   *event.Feed    // Used to enable P2P related interactions via different sharding actors.
 
 	// Lifecycle and service stores.
-	services     map[reflect.Type]types.Service // Service registry.
-	serviceTypes []reflect.Type                 // Keeps an ordered slice of registered service types.
-	lock         sync.RWMutex
-	stop         chan struct{} // Channel to wait for termination notifications
+	services *shared.ServiceRegistry
+	lock     sync.RWMutex
+	stop     chan struct{} // Channel to wait for termination notifications
 }
 
 // New creates a new sharding-enabled Ethereum instance. This is called in the main
 // geth sharding entrypoint.
 func New(ctx *cli.Context) (*ShardEthereum, error) {
+	registry := shared.NewServiceRegistry()
 	shardEthereum := &ShardEthereum{
-		services: make(map[reflect.Type]types.Service),
+		services: registry,
 		stop:     make(chan struct{}),
 	}
 
@@ -99,10 +99,9 @@ func (s *ShardEthereum) Start() {
 
 	log.Info("Starting sharding node")
 
-	for _, kind := range s.serviceTypes {
-		// Start each service in order of registration.
-		s.services[kind].Start()
-	}
+	// Starts all services registered to the ShardEthereum instance in order of
+	// registration.
+	s.services.StartAll()
 
 	stop := s.stop
 	s.lock.Unlock()
@@ -133,42 +132,12 @@ func (s *ShardEthereum) Close() {
 	s.lock.Lock()
 	defer s.lock.Unlock()
 
-	for kind, service := range s.services {
-		if err := service.Stop(); err != nil {
-			log.Panicf("Could not stop the following service: %v, %v", kind, err)
-		}
-	}
+	// Stops all services registered to the ShardEthereum instance.
+	s.services.StopAll()
 	log.Info("Stopping sharding node")
 
 	// unblock n.Wait
 	close(s.stop)
-}
-
-// registerService appends a service constructor function to the service registry of the
-// sharding node.
-func (s *ShardEthereum) registerService(service types.Service) error {
-	kind := reflect.TypeOf(service)
-	if _, exists := s.services[kind]; exists {
-		return fmt.Errorf("service already exists: %v", kind)
-	}
-	s.services[kind] = service
-	s.serviceTypes = append(s.serviceTypes, kind)
-	return nil
-}
-
-// fetchService takes in a struct pointer and sets the value of that pointer
-// to a service currently stored in the service registry. This ensures the input argument is
-// set to the right pointer that refers to the originally registered service.
-func (s *ShardEthereum) fetchService(service interface{}) error {
-	if reflect.TypeOf(service).Kind() != reflect.Ptr {
-		return fmt.Errorf("input must be of pointer type, received value type instead: %T", service)
-	}
-	element := reflect.ValueOf(service).Elem()
-	if running, ok := s.services[element.Type()]; ok {
-		element.Set(reflect.ValueOf(running))
-		return nil
-	}
-	return fmt.Errorf("unknown service: %T", service)
 }
 
 // registerShardChainDB attaches a LevelDB wrapped object to the shardEthereum instance.
@@ -181,18 +150,16 @@ func (s *ShardEthereum) registerShardChainDB(ctx *cli.Context) error {
 	if err != nil {
 		return fmt.Errorf("could not register shardDB service: %v", err)
 	}
-	return s.registerService(shardDB)
+	return s.services.RegisterService(shardDB)
 }
 
 // registerP2P attaches a p2p server to the ShardEthereum instance.
-// TODO: Design this p2p service and the methods it should expose as well as
-// its event loop.
 func (s *ShardEthereum) registerP2P() error {
 	shardp2p, err := p2p.NewServer()
 	if err != nil {
 		return fmt.Errorf("could not register shardp2p service: %v", err)
 	}
-	return s.registerService(shardp2p)
+	return s.services.RegisterService(shardp2p)
 }
 
 // registerMainchainClient
@@ -216,7 +183,7 @@ func (s *ShardEthereum) registerMainchainClient(ctx *cli.Context) error {
 	if err != nil {
 		return fmt.Errorf("could not register smc client service: %v", err)
 	}
-	return s.registerService(client)
+	return s.services.RegisterService(client)
 }
 
 // registerTXPool is only relevant to proposers in the sharded system. It will
@@ -229,34 +196,34 @@ func (s *ShardEthereum) registerTXPool(actor string) error {
 		return nil
 	}
 	var shardp2p *p2p.Server
-	if err := s.fetchService(&shardp2p); err != nil {
+	if err := s.services.FetchService(&shardp2p); err != nil {
 		return err
 	}
 	pool, err := txpool.NewTXPool(shardp2p)
 	if err != nil {
 		return fmt.Errorf("could not register shard txpool service: %v", err)
 	}
-	return s.registerService(pool)
+	return s.services.RegisterService(pool)
 }
 
 // Registers the actor according to CLI flags. Either notary/proposer/observer.
 func (s *ShardEthereum) registerActorService(config *params.Config, actor string, shardID int) error {
 	var shardp2p *p2p.Server
-	if err := s.fetchService(&shardp2p); err != nil {
+	if err := s.services.FetchService(&shardp2p); err != nil {
 		return err
 	}
 	var client *mainchain.SMCClient
-	if err := s.fetchService(&client); err != nil {
+	if err := s.services.FetchService(&client); err != nil {
 		return err
 	}
 
 	var shardChainDB *database.ShardDB
-	if err := s.fetchService(&shardChainDB); err != nil {
+	if err := s.services.FetchService(&shardChainDB); err != nil {
 		return err
 	}
 
 	var sync *syncer.Syncer
-	if err := s.fetchService(&sync); err != nil {
+	if err := s.services.FetchService(&sync); err != nil {
 		return err
 	}
 
@@ -266,10 +233,10 @@ func (s *ShardEthereum) registerActorService(config *params.Config, actor string
 		if err != nil {
 			return fmt.Errorf("could not register notary service: %v", err)
 		}
-		return s.registerService(not)
+		return s.services.RegisterService(not)
 	case "proposer":
 		var pool *txpool.TXPool
-		if err := s.fetchService(&pool); err != nil {
+		if err := s.services.FetchService(&pool); err != nil {
 			return err
 		}
 
@@ -277,19 +244,19 @@ func (s *ShardEthereum) registerActorService(config *params.Config, actor string
 		if err != nil {
 			return fmt.Errorf("could not register proposer service: %v", err)
 		}
-		return s.registerService(prop)
+		return s.services.RegisterService(prop)
 	case "simulator":
 		sim, err := simulator.NewSimulator(config, client, shardp2p, shardID, 15) // 15 second delay between simulator requests.
 		if err != nil {
 			return fmt.Errorf("could not register simulator service: %v", err)
 		}
-		return s.registerService(sim)
+		return s.services.RegisterService(sim)
 	default:
 		obs, err := observer.NewObserver(shardp2p, shardChainDB, shardID, sync, client)
 		if err != nil {
 			return fmt.Errorf("could not register observer service: %v", err)
 		}
-		return s.registerService(obs)
+		return s.services.RegisterService(obs)
 	}
 }
 
@@ -301,11 +268,11 @@ func (s *ShardEthereum) registerSimulatorService(actorFlag string, config *param
 	}
 
 	var shardp2p *p2p.Server
-	if err := s.fetchService(&shardp2p); err != nil {
+	if err := s.services.FetchService(&shardp2p); err != nil {
 		return err
 	}
 	var client *mainchain.SMCClient
-	if err := s.fetchService(&client); err != nil {
+	if err := s.services.FetchService(&client); err != nil {
 		return err
 	}
 
@@ -314,21 +281,21 @@ func (s *ShardEthereum) registerSimulatorService(actorFlag string, config *param
 	if err != nil {
 		return fmt.Errorf("could not register simulator service: %v", err)
 	}
-	return s.registerService(sim)
+	return s.services.RegisterService(sim)
 }
 
 func (s *ShardEthereum) registerSyncerService(config *params.Config, shardID int) error {
 	var shardp2p *p2p.Server
-	if err := s.fetchService(&shardp2p); err != nil {
+	if err := s.services.FetchService(&shardp2p); err != nil {
 		return err
 	}
 	var client *mainchain.SMCClient
-	if err := s.fetchService(&client); err != nil {
+	if err := s.services.FetchService(&client); err != nil {
 		return err
 	}
 
 	var shardChainDB *database.ShardDB
-	if err := s.fetchService(&shardChainDB); err != nil {
+	if err := s.services.FetchService(&shardChainDB); err != nil {
 		return err
 	}
 
@@ -336,5 +303,5 @@ func (s *ShardEthereum) registerSyncerService(config *params.Config, shardID int
 	if err != nil {
 		return fmt.Errorf("could not register syncer service: %v", err)
 	}
-	return s.registerService(sync)
+	return s.services.RegisterService(sync)
 }

--- a/sharding/node/backend.go
+++ b/sharding/node/backend.go
@@ -45,7 +45,7 @@ type ShardEthereum struct {
 	// Lifecycle and service stores.
 	services *shared.ServiceRegistry
 	lock     sync.RWMutex
-	stop     chan struct{} // Channel to wait for termination notifications
+	stop     chan struct{} // Channel to wait for termination notifications.
 }
 
 // New creates a new sharding-enabled Ethereum instance. This is called in the main

--- a/shared/BUILD.bazel
+++ b/shared/BUILD.bazel
@@ -2,7 +2,11 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
-    srcs = ["marshal.go"],
+    srcs = [
+        "marshal.go",
+        "service_registry.go",
+        "types.go",
+    ],
     importpath = "github.com/prysmaticlabs/geth-sharding/shared",
     visibility = ["//visibility:public"],
     deps = ["@com_github_ethereum_go_ethereum//rlp:go_default_library"],
@@ -10,6 +14,9 @@ go_library(
 
 go_test(
     name = "go_default_test",
-    srcs = ["marshal_test.go"],
+    srcs = [
+        "marshal_test.go",
+        "service_registry_test.go",
+    ],
     embed = [":go_default_library"],
 )

--- a/shared/service_registry.go
+++ b/shared/service_registry.go
@@ -6,15 +6,9 @@ import (
 	"reflect"
 )
 
-// ServiceRegistry provides a useful pattern for managing services attached to a struct.
-// This can be used for managing routines that are part of items such as a
-// beacon chain node, or a sharding client. That is, it allows for ease of dependency
-// management and ensures services dependent on others use the same references in memory.
-//
-// A beacon chain node, for example, has various services including p2p, proposers, attesters,
-// and more. Proposers depend on p2p, so upon registering a proposer service, a p2p service
-// can be fetched from the service registry and passed into the p2p constructor.
-// See beacon-chain/node/node.go for examples.
+// ServiceRegistry provides a useful pattern for managing services.
+// It allows for ease of dependency management and ensures services
+// dependent on others use the same references in memory.
 type ServiceRegistry struct {
 	services     map[reflect.Type]Service // map of types to services.
 	serviceTypes []reflect.Type           // keep an ordered slice of registered service types.

--- a/shared/service_registry.go
+++ b/shared/service_registry.go
@@ -1,0 +1,71 @@
+package shared
+
+import (
+	"fmt"
+	"log"
+	"reflect"
+)
+
+// ServiceRegistry provides a useful pattern for managing services attached to a struct.
+// This can be used for managing routines that are part of items such as a
+// beacon chain node, or a sharding client. That is, it allows for ease of dependency
+// management and ensures services dependent on others use the same references in memory.
+//
+// A beacon chain node, for example, has various services including p2p, proposers, attesters,
+// and more. Proposers depend on p2p, so upon registering a proposer service, a p2p service
+// can be fetched from the service registry and passed into the p2p constructor.
+// See beacon-chain/node/node.go for examples.
+type ServiceRegistry struct {
+	services     map[reflect.Type]Service // map of types to services.
+	serviceTypes []reflect.Type           // keep an ordered slice of registered service types.
+}
+
+// NewServiceRegistry starts a registry instance for convenience
+func NewServiceRegistry() *ServiceRegistry {
+	return &ServiceRegistry{
+		services: make(map[reflect.Type]Service),
+	}
+}
+
+// StartAll initialized each service in order of registration.
+func (s *ServiceRegistry) StartAll() {
+	for _, kind := range s.serviceTypes {
+		s.services[kind].Start()
+	}
+}
+
+// StopAll ends every service, logging a panic if any of them fail to stop.
+func (s *ServiceRegistry) StopAll() {
+	for kind, service := range s.services {
+		if err := service.Stop(); err != nil {
+			log.Panicf("Could not stop the following service: %v, %v", kind, err)
+		}
+	}
+}
+
+// RegisterService appends a service constructor function to the service
+// registry.
+func (s *ServiceRegistry) RegisterService(service Service) error {
+	kind := reflect.TypeOf(service)
+	if _, exists := s.services[kind]; exists {
+		return fmt.Errorf("service already exists: %v", kind)
+	}
+	s.services[kind] = service
+	s.serviceTypes = append(s.serviceTypes, kind)
+	return nil
+}
+
+// FetchService takes in a struct pointer and sets the value of that pointer
+// to a service currently stored in the service registry. This ensures the input argument is
+// set to the right pointer that refers to the originally registered service.
+func (s *ServiceRegistry) FetchService(service interface{}) error {
+	if reflect.TypeOf(service).Kind() != reflect.Ptr {
+		return fmt.Errorf("input must be of pointer type, received value type instead: %T", service)
+	}
+	element := reflect.ValueOf(service).Elem()
+	if running, ok := s.services[element.Type()]; ok {
+		element.Set(reflect.ValueOf(running))
+		return nil
+	}
+	return fmt.Errorf("unknown service: %T", service)
+}

--- a/shared/service_registry_test.go
+++ b/shared/service_registry_test.go
@@ -34,7 +34,7 @@ func TestRegisterServiceTwice(t *testing.T) {
 		t.Fatalf("failed to register first service")
 	}
 
-	// checks if first service was indeed registered
+	// Checks if first service was indeed registered.
 	if len(registry.serviceTypes) != 1 {
 		t.Fatalf("service types slice should contain 1 service, contained %v", len(registry.serviceTypes))
 	}

--- a/shared/service_registry_test.go
+++ b/shared/service_registry_test.go
@@ -1,0 +1,102 @@
+package shared
+
+import (
+	"reflect"
+	"testing"
+)
+
+type mockService struct{}
+type secondMockService struct{}
+
+func (m *mockService) Start() {
+	return
+}
+
+func (m *mockService) Stop() error {
+	return nil
+}
+
+func (s *secondMockService) Start() {
+	return
+}
+
+func (s *secondMockService) Stop() error {
+	return nil
+}
+
+func TestRegisterServiceTwice(t *testing.T) {
+	registry := &ServiceRegistry{
+		services: make(map[reflect.Type]Service),
+	}
+
+	m := &mockService{}
+	if err := registry.RegisterService(m); err != nil {
+		t.Fatalf("failed to register first service")
+	}
+
+	// checks if first service was indeed registered
+	if len(registry.serviceTypes) != 1 {
+		t.Fatalf("service types slice should contain 1 service, contained %v", len(registry.serviceTypes))
+	}
+
+	if err := registry.RegisterService(m); err == nil {
+		t.Errorf("should not be able to register a service twice, got nil error")
+	}
+}
+
+func TestRegisterDifferentServices(t *testing.T) {
+	registry := &ServiceRegistry{
+		services: make(map[reflect.Type]Service),
+	}
+
+	m := &mockService{}
+	s := &secondMockService{}
+	if err := registry.RegisterService(m); err != nil {
+		t.Fatalf("failed to register first service")
+	}
+
+	if err := registry.RegisterService(s); err != nil {
+		t.Fatalf("failed to register second service")
+	}
+
+	if len(registry.serviceTypes) != 2 {
+		t.Errorf("service types slice should contain 2 services, contained %v", len(registry.serviceTypes))
+	}
+
+	if _, exists := registry.services[reflect.TypeOf(m)]; !exists {
+		t.Errorf("service of type %v not registered", reflect.TypeOf(m))
+	}
+
+	if _, exists := registry.services[reflect.TypeOf(s)]; !exists {
+		t.Errorf("service of type %v not registered", reflect.TypeOf(s))
+	}
+}
+
+func TestFetchService(t *testing.T) {
+	registry := &ServiceRegistry{
+		services: make(map[reflect.Type]Service),
+	}
+
+	m := &mockService{}
+	if err := registry.RegisterService(m); err != nil {
+		t.Fatalf("failed to register first service")
+	}
+
+	if err := registry.FetchService(*m); err == nil {
+		t.Errorf("passing in a value should throw an error, received nil error")
+	}
+
+	var s *secondMockService
+	if err := registry.FetchService(&s); err == nil {
+		t.Errorf("fetching an unregistered service should return an error, got nil")
+	}
+
+	var m2 *mockService
+	if err := registry.FetchService(&m2); err != nil {
+		t.Fatalf("failed to fetch service")
+	}
+
+	if m2 != m {
+		t.Errorf("pointers were not equal, instead got %p, %p", m2, m)
+	}
+}

--- a/shared/types.go
+++ b/shared/types.go
@@ -1,0 +1,14 @@
+package shared
+
+// Service is a struct that can be registered into a ServiceRegistry.  Using a
+// ServiceRegistry for easy dependency management. For example, a proposer
+// service might depend on a p2p server, a txpool, an smc client, etc, but
+// we want this proposer to have the same copy of the p2p server all other
+// services use in-memory.
+type Service interface {
+	// Start spawns any goroutines required by the service.
+	Start()
+	// Stop terminates all goroutines belonging to the service,
+	// blocking until they are all terminated.
+	Stop() error
+}

--- a/shared/types.go
+++ b/shared/types.go
@@ -1,10 +1,7 @@
 package shared
 
-// Service is a struct that can be registered into a ServiceRegistry.  Using a
-// ServiceRegistry for easy dependency management. For example, a proposer
-// service might depend on a p2p server, a txpool, an smc client, etc, but
-// we want this proposer to have the same copy of the p2p server all other
-// services use in-memory.
+// Service is a struct that can be registered into a ServiceRegistry for
+// easy dependency management.
 type Service interface {
 	// Start spawns any goroutines required by the service.
 	Start()


### PR DESCRIPTION
Hi all,

This resolves #262. This PR abstracts the service registry structure we have been using for a sharding node into the shared package where it is well-documented and tested. We then import this service registry to use in the creation of a beacon chain node as well as in a sharding client. I have also added a main entry point for a beacon node which can be built using:

```
bazel build //beacon-chain/...
```

and then the binary can be run:

```
./bazel-bin/beacon-chain/YOURARCHITECTURE/beacon-chain
```