### PR TITLE
Abstract Debug Into Shared/Debug and Reinclude Debug.Exit()

### DIFF
--- a/beacon-chain/BUILD.bazel
+++ b/beacon-chain/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//beacon-chain:__subpackages__"],
     deps = [
         "//beacon-chain/node:go_default_library",
+        "//shared/debug:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@com_github_urfave_cli//:go_default_library",
     ],

--- a/beacon-chain/main.go
+++ b/beacon-chain/main.go
@@ -5,6 +5,7 @@ import (
 	"runtime"
 
 	"github.com/prysmaticlabs/geth-sharding/beacon-chain/node"
+	"github.com/prysmaticlabs/geth-sharding/shared/debug"
 	log "github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 )
@@ -20,12 +21,35 @@ func startNode(ctx *cli.Context) error {
 
 func main() {
 	app := cli.NewApp()
+	cli.AppHelpTemplate = `NAME:
+   {{.Name}} - {{.Usage}}
+USAGE:
+   {{.HelpName}} {{if .VisibleFlags}}[global options]{{end}}
+   {{if len .Authors}}
+AUTHOR:
+   {{range .Authors}}{{ . }}{{end}}
+   {{end}}{{if .Commands}}
+GLOBAL OPTIONS:
+   {{range .VisibleFlags}}{{.}}
+   {{end}}{{end}}{{if .Copyright }}
+COPYRIGHT:
+   {{.Copyright}}
+   {{end}}{{if .Version}}
+VERSION:
+   {{.Version}}
+   {{end}}
+`
 	app.Name = "beacon-chain"
 	app.Usage = "this is a beacon chain implementation for Ethereum 2.0"
 	app.Action = startNode
 
+	app.Flags = []cli.Flag{debug.PProfFlag, debug.PProfAddrFlag, debug.PProfPortFlag, debug.MemProfileRateFlag, debug.CPUProfileFlag, debug.TraceFlag}
+
 	app.Before = func(ctx *cli.Context) error {
 		runtime.GOMAXPROCS(runtime.NumCPU())
+		if err := debug.Setup(ctx); err != nil {
+			return err
+		}
 		return nil
 	}
 

--- a/beacon-chain/node/BUILD.bazel
+++ b/beacon-chain/node/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//beacon-chain:__subpackages__"],
     deps = [
         "//shared:go_default_library",
+        "//shared/debug:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@com_github_urfave_cli//:go_default_library",
     ],

--- a/beacon-chain/node/node.go
+++ b/beacon-chain/node/node.go
@@ -7,6 +7,7 @@ import (
 	"syscall"
 
 	"github.com/prysmaticlabs/geth-sharding/shared"
+	"github.com/prysmaticlabs/geth-sharding/shared/debug"
 	log "github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 )
@@ -56,6 +57,7 @@ func (b *BeaconNode) Start() {
 				log.Info("Already shutting down, interrupt more to panic.", "times", i-1)
 			}
 		}
+		debug.Exit() // Ensure trace and CPU profile data are flushed.
 		panic("Panic closing the beacon node")
 	}()
 

--- a/sharding/BUILD.bazel
+++ b/sharding/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
     deps = [
         "//sharding/node:go_default_library",
         "//sharding/utils:go_default_library",
+        "//shared/debug:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@com_github_urfave_cli//:go_default_library",
     ],

--- a/sharding/main.go
+++ b/sharding/main.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/prysmaticlabs/geth-sharding/sharding/node"
 	"github.com/prysmaticlabs/geth-sharding/sharding/utils"
+	"github.com/prysmaticlabs/geth-sharding/shared/debug"
 	log "github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 )
@@ -45,18 +46,18 @@ VERSION:
 	app.Usage = `launches a sharding client that interacts with a beacon chain, starts proposer services, shardp2p connections, and more
 `
 	app.Action = startNode
-	app.Flags = []cli.Flag{utils.ActorFlag, utils.DataDirFlag, utils.PasswordFileFlag, utils.NetworkIdFlag, utils.IPCPathFlag, utils.DepositFlag, utils.ShardIDFlag, utils.PProfFlag, utils.PProfAddrFlag, utils.PProfPortFlag, utils.MemProfileRateFlag, utils.CPUProfileFlag, utils.TraceFlag}
+	app.Flags = []cli.Flag{utils.ActorFlag, utils.DataDirFlag, utils.PasswordFileFlag, utils.NetworkIdFlag, utils.IPCPathFlag, utils.DepositFlag, utils.ShardIDFlag, debug.PProfFlag, debug.PProfAddrFlag, debug.PProfPortFlag, debug.MemProfileRateFlag, debug.CPUProfileFlag, debug.TraceFlag}
 
 	app.Before = func(ctx *cli.Context) error {
 		runtime.GOMAXPROCS(runtime.NumCPU())
-		if err := utils.Setup(ctx); err != nil {
+		if err := debug.Setup(ctx); err != nil {
 			return err
 		}
 		return nil
 	}
 
 	app.After = func(ctx *cli.Context) error {
-		utils.Exit()
+		debug.Exit()
 		return nil
 	}
 

--- a/sharding/node/BUILD.bazel
+++ b/sharding/node/BUILD.bazel
@@ -19,6 +19,7 @@ go_library(
         "//sharding/types:go_default_library",
         "//sharding/utils:go_default_library",
         "//shared:go_default_library",
+        "//shared/debug:go_default_library",
         "@com_github_ethereum_go_ethereum//event:go_default_library",
         "@com_github_ethereum_go_ethereum//node:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",

--- a/sharding/node/backend.go
+++ b/sharding/node/backend.go
@@ -27,6 +27,7 @@ import (
 	"github.com/prysmaticlabs/geth-sharding/sharding/types"
 	"github.com/prysmaticlabs/geth-sharding/sharding/utils"
 	"github.com/prysmaticlabs/geth-sharding/shared"
+	"github.com/prysmaticlabs/geth-sharding/shared/debug"
 	log "github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 )
@@ -117,6 +118,7 @@ func (s *ShardEthereum) Start() {
 				log.Info("Already shutting down, interrupt more to panic.", "times", i-1)
 			}
 		}
+		debug.Exit() // Ensure trace and CPU profile data are flushed.
 		panic("Panic closing the sharding node")
 	}()
 

--- a/sharding/utils/BUILD.bazel
+++ b/sharding/utils/BUILD.bazel
@@ -4,7 +4,6 @@ go_library(
     name = "go_default_library",
     srcs = [
         "customflags.go",
-        "debug.go",
         "flags.go",
         "service.go",
     ],
@@ -13,7 +12,6 @@ go_library(
     deps = [
         "//sharding/params:go_default_library",
         "@com_github_ethereum_go_ethereum//node:go_default_library",
-        "@com_github_fjl_memsize//memsizeui:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@com_github_urfave_cli//:go_default_library",
     ],

--- a/sharding/utils/flags.go
+++ b/sharding/utils/flags.go
@@ -18,55 +18,14 @@
 package utils
 
 import (
-	"fmt"
 	"math/big"
-	"net/http"
-	"runtime"
 
 	"github.com/ethereum/go-ethereum/node"
-	"github.com/fjl/memsize/memsizeui"
 	shardparams "github.com/prysmaticlabs/geth-sharding/sharding/params"
-	log "github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 )
 
-var Memsize memsizeui.Handler
-
-// These are all the command line flags we support.
-// If you add to this list, please remember to include the
-// flag in the appropriate command definition.
-//
-// The flags are defined here so their names and help texts
-// are the same for all commands.
 var (
-	// Debug Flags
-	PProfFlag = cli.BoolFlag{
-		Name:  "pprof",
-		Usage: "Enable the pprof HTTP server",
-	}
-	PProfPortFlag = cli.IntFlag{
-		Name:  "pprofport",
-		Usage: "pprof HTTP server listening port",
-		Value: 6060,
-	}
-	PProfAddrFlag = cli.StringFlag{
-		Name:  "pprofaddr",
-		Usage: "pprof HTTP server listening interface",
-		Value: "127.0.0.1",
-	}
-	MemProfileRateFlag = cli.IntFlag{
-		Name:  "memprofilerate",
-		Usage: "Turn on memory profiling with the given rate",
-		Value: runtime.MemProfileRate,
-	}
-	CPUProfileFlag = cli.StringFlag{
-		Name:  "cpuprofile",
-		Usage: "Write CPU profile to the given file",
-	}
-	TraceFlag = cli.StringFlag{
-		Name:  "trace",
-		Usage: "Write execution trace to the given file",
-	}
 	// General settings
 	IPCPathFlag = DirectoryFlag{
 		Name:  "ipcpath",
@@ -101,70 +60,3 @@ var (
 		Usage: `use the --shardid to determine which shard to start p2p server, listen for incoming transactions and perform proposer/observer duties`,
 	}
 )
-
-// MigrateFlags sets the global flag from a local flag when it's set.
-// This is a temporary function used for migrating old command/flags to the
-// new format.
-//
-// e.g. geth account new --keystore /tmp/mykeystore --lightkdf
-//
-// is equivalent after calling this method with:
-//
-// geth --keystore /tmp/mykeystore --lightkdf account new
-//
-// This allows the use of the existing configuration functionality.
-// When all flags are migrated this function can be removed and the existing
-// configuration functionality must be changed that is uses local flags
-func MigrateFlags(action func(ctx *cli.Context) error) func(*cli.Context) error {
-	return func(ctx *cli.Context) error {
-		for _, name := range ctx.FlagNames() {
-			if ctx.IsSet(name) {
-				ctx.GlobalSet(name, ctx.String(name))
-			}
-		}
-		return action(ctx)
-	}
-}
-
-// Debug setup and exit functions.
-
-// Setup initializes profiling based on the CLI flags.
-// It should be called as early as possible in the program.
-func Setup(ctx *cli.Context) error {
-	// profiling, tracing
-	runtime.MemProfileRate = ctx.GlobalInt(MemProfileRateFlag.Name)
-	if traceFile := ctx.GlobalString(TraceFlag.Name); traceFile != "" {
-		if err := Handler.StartGoTrace(TraceFlag.Name); err != nil {
-			return err
-		}
-	}
-	if cpuFile := ctx.GlobalString(CPUProfileFlag.Name); cpuFile != "" {
-		if err := Handler.StartCPUProfile(cpuFile); err != nil {
-			return err
-		}
-	}
-
-	// pprof server
-	if ctx.GlobalBool(PProfFlag.Name) {
-		address := fmt.Sprintf("%s:%d", ctx.GlobalString(PProfAddrFlag.Name), ctx.GlobalInt(PProfPortFlag.Name))
-		StartPProf(address)
-	}
-	return nil
-}
-
-func StartPProf(address string) {
-	http.Handle("/memsize/", http.StripPrefix("/memsize", &Memsize))
-	log.Info("Starting pprof server", "addr", fmt.Sprintf("http://%s/debug/pprof", address))
-	go func() {
-		if err := http.ListenAndServe(address, nil); err != nil {
-			log.Error("Failure in running pprof server", "err", err)
-		}
-	}()
-}
-
-// Exit stops all running profiles, flushing their output to the
-// respective file.
-func Exit() {
-	Handler.StopCPUProfile()
-	Handler.StopGoTrace()
-}

--- a/shared/debug/BUILD.bazel
+++ b/shared/debug/BUILD.bazel
@@ -1,0 +1,13 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["debug.go"],
+    importpath = "github.com/prysmaticlabs/geth-sharding/shared/debug",
+    visibility = ["//visibility:public"],
+    deps = [
+        "@com_github_fjl_memsize//memsizeui:go_default_library",
+        "@com_github_sirupsen_logrus//:go_default_library",
+        "@com_github_urfave_cli//:go_default_library",
+    ],
+)


### PR DESCRIPTION
Hi all,

This PR resolves #274 and attaches debug flags to the beacon node endpoint. It also calls debug.Exit() to ensure CPU profile data and trace are flushed. Geth's license header is kept in the debug.go file to give credit.