### PR TITLE
Update go-ethereum with fix for mac OS builds

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -32,8 +32,8 @@ go_repository(
     # code.
     remote = "https://github.com/prysmaticlabs/bazel-go-ethereum",
     vcs = "git",
-    # Last updated July 5, 2018
-    commit = "eb95493d32b6e1eb1cad63518637e1a958632389",
+    # Last updated July 15, 2018
+    commit = "fad71da72e539ff79183a5d548b105c73ce4969f",
 )
 
 go_repository(


### PR DESCRIPTION
I tested this on a 2015 Macbook with Bazel `0.14.1`.

`bazel test //...` was able to build and execute tests appropriately. 

```
$ ~/bin/bazel version
Build label: 0.14.1
Build target: bazel-out/darwin-opt/bin/src/main/java/com/google/devtools/build/lib/bazel/BazelServer_deploy.jar
Build time: Fri Jun 8 12:17:00 2018 (1528460220)
Build timestamp: 1528460220
Build timestamp as int: 1528460220
```

```
$ ~/bin/bazel test //... --flaky_test_attempts=3
INFO: Analysed 45 targets (0 packages loaded).
INFO: Found 27 targets and 18 test targets...
INFO: Elapsed time: 126.255s, Critical Path: 125.18s
INFO: 2 processes, darwin-sandbox.
INFO: Build completed successfully, 3 total actions
//beacon-chain/node:go_default_test                             (cached) PASSED in 0.5s
//beacon-chain/powchain:go_default_test                         (cached) PASSED in 0.4s
//contracts:go_default_test                                     (cached) PASSED in 0.6s
//sharding/database:go_default_test                             (cached) PASSED in 0.4s
//sharding/mainchain:go_default_test                            (cached) PASSED in 2.6s
//sharding/node:go_default_test                                 (cached) PASSED in 0.6s
//sharding/observer:go_default_test                             (cached) PASSED in 0.5s
//sharding/p2p:go_default_test                                  (cached) PASSED in 0.6s
//sharding/params:go_default_test                               (cached) PASSED in 0.4s
//sharding/proposer:go_default_test                             (cached) PASSED in 1.5s
//sharding/simulator:go_default_test                            (cached) PASSED in 0.5s
//sharding/syncer:go_default_test                               (cached) PASSED in 0.6s
//sharding/txpool:go_default_test                               (cached) PASSED in 0.3s
//sharding/types:go_default_test                                (cached) PASSED in 0.6s
//sharding/utils:go_default_test                                (cached) PASSED in 0.5s
//shared:go_default_test                                        (cached) PASSED in 7.3s
//sharding/contracts:go_default_test                                     PASSED in 86.8s
//sharding/notary:go_default_test                                        PASSED in 125.2s

Executed 2 out of 18 tests: 18 tests pass.
INFO: Build completed successfully, 3 total actions
```