### PR TITLE
Update Readme to Execute Binary Instead of Bazel Run

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ $ bazel build //sharding/...
 Make sure a geth node is running as a separate process. Then, to deposit ETH and join as a notary in the Sharding Manager Contract, run the following command:
 
 ```
-$ bazel run //sharding --actor "notary" --deposit --datadir /path/to/your/datadir --password /path/to/your/password.txt --networkid 12345
+$ ./bazel-bin/path/to/your/sharding/binary  --actor "notary" --deposit --datadir /path/to/your/datadir --password /path/to/your/password.txt --networkid 12345
 ```
 
 This will extract 1000ETH from your account balance and insert you into the SMC's notaries. Then, the program will listen for incoming block headers and notify you when you have been selected as to vote on proposals for a certain shard in a given period. Once you are selected, your sharding node will download collation information to check for data availability on vote on proposals that have been submitted via the `addHeader` function on the SMC.
@@ -117,14 +117,14 @@ Concurrently, you will need to run another service that is tasked with processin
 ## Running a Collation Proposal Node
 
 ```
-$ bazel run //sharding --actor "proposer" --datadir /path/to/your/datadir --password /path/to/your/password.txt --shardid 0 --networkid 12345
+$ ./bazel-bin/path/to/your/sharding/binary --actor "proposer" --datadir /path/to/your/datadir --password /path/to/your/password.txt --shardid 0 --networkid 12345
 ```
 
 This node is tasked with processing pending transactions into blobs within collations by serializing data into collation bodies. It is responsible for submitting proposals on shard 0 (collation headers) to the SMC via the `addHeader` function.
 
 ## Running an Observer Node
 
-    $ bazel run //sharding --datadir /path/to/your/datadir --password /path/to/your/password.txt --shardid 0 --networkid 12345
+    $ ./bazel-bin/path/to/your/sharding/binary --datadir /path/to/your/datadir --password /path/to/your/password.txt --shardid 0 --networkid 12345
 
 Omitting the `--actor` flag will launch a simple observer service attached to the sharding client that is able to listen to changes happening throughout the sharded Ethereum network on shard 0.
 


### PR DESCRIPTION
Updated in readme to use the binary intead of `bazel run` since `bazel run` isnt very good