### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,29 +25,24 @@ Also, read our [Sharding Reference Implementation Doc](https://github.com/prysma
 Create a folder in your `$GOPATH` and navigate to it
 
 ```
-$ mkdir -p $GOPATH/src/github.com/prysmaticlabs && cd $GOPATH/src/github.com/prysmaticlabs
+mkdir -p $GOPATH/src/github.com/prysmaticlabs && cd $GOPATH/src/github.com/prysmaticlabs
 ```
+
+Note: it is not necessary to clone to the gopath if you're only building with Bazel. 
 
 Clone our repository: 
 
 ```
-$ git clone https://github.com/prysmaticlabs/geth-sharding
+git clone https://github.com/prysmaticlabs/geth-sharding
 ```
 
 Download the Bazel build tool by Google [here](https://docs.bazel.build/versions/master/install.html) and ensure it works by typing
 
 ```
-$ bazel
+bazel version
 ```
 
-You will also need to download Geth:
-
-```
-$ go get -u github.com/ethereum/go-ethereum
-```
-
-Building geth requires both a Go (version 1.7 or later) and a C compiler.
-You can install them using your favourite package manager.
+Bazel manages all of the dependencies for you (including go and necessary compilers) so you are all set to build geth-sharding.
 
 # Sharding Instructions
 
@@ -107,7 +102,12 @@ $ bazel build //sharding/...
 Make sure a geth node is running as a separate process. Then, to deposit ETH and join as a notary in the Sharding Manager Contract, run the following command:
 
 ```
-$ ./bazel-bin/path/to/your/sharding/binary  --actor "notary" --deposit --datadir /path/to/your/datadir --password /path/to/your/password.txt --networkid 12345
+bazel run //sharding -- \
+   --actor "notary" \
+   --deposit \
+   --datadir /path/to/your/datadir \
+   --password /path/to/your/password.txt \
+   --networkid 12345
 ```
 
 This will extract 1000ETH from your account balance and insert you into the SMC's notaries. Then, the program will listen for incoming block headers and notify you when you have been selected as to vote on proposals for a certain shard in a given period. Once you are selected, your sharding node will download collation information to check for data availability on vote on proposals that have been submitted via the `addHeader` function on the SMC.
@@ -117,14 +117,25 @@ Concurrently, you will need to run another service that is tasked with processin
 ## Running a Collation Proposal Node
 
 ```
-$ ./bazel-bin/path/to/your/sharding/binary --actor "proposer" --datadir /path/to/your/datadir --password /path/to/your/password.txt --shardid 0 --networkid 12345
+bazel run //sharding -- \
+   --actor "proposer" \
+   --datadir /path/to/your/datadir \
+   --password /path/to/your/password.txt \
+   --shardid 0 \
+   --networkid 12345
 ```
 
 This node is tasked with processing pending transactions into blobs within collations by serializing data into collation bodies. It is responsible for submitting proposals on shard 0 (collation headers) to the SMC via the `addHeader` function.
 
 ## Running an Observer Node
 
-    $ ./bazel-bin/path/to/your/sharding/binary --datadir /path/to/your/datadir --password /path/to/your/password.txt --shardid 0 --networkid 12345
+```
+bazel run //sharding -- \
+   --datadir /path/to/your/datadir \
+   --password /path/to/your/password.txt \
+   --shardid 0 \
+   --networkid 12345
+```
 
 Omitting the `--actor` flag will launch a simple observer service attached to the sharding client that is able to listen to changes happening throughout the sharded Ethereum network on shard 0.
 
@@ -149,7 +160,7 @@ $ bazel test //...
 To run our linter, make sure you have [gometalinter](https://github.com/alecthomas/gometalinter) installed and then run
 
 ```
-$ gometalinter ./
+$ gometalinter ./...
 ```
 
 # Contributing


### PR DESCRIPTION
Having the dollar sign is annoying when copying examples.

Having long commands on one line is hard to read so I fixed these issues.

I also added examples using bazel run as the canonical way to run the project.